### PR TITLE
feat: Scan Artist by URL + Deezer NRD improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A modular music automation platform that bridges services for your self-hosted m
 ### 🎵 **Automatic Music Discovery**
 - **Find Similar Artists**: Automatically discovers new artists similar to those in your Lidarr library using Last.fm
 - **Playlist-Based Discovery**: Discovers artists from synced playlists and adds them directly to Lidarr
-- **New Releases Discovery**: Find Deezer (or Spotify) releases from your Lidarr artists that are missing from MusicBrainz—add them via Harmony with one click
+- **New Releases Discovery**: Find Deezer (or Spotify) releases from your Lidarr artists that are missing from MusicBrainz—add them via Harmony with one click. Artist not in Lidarr yet? Paste a Spotify or Deezer artist URL to compare all albums to MusicBrainz and get a list of missing releases with Harmony links.
 - **Smart Filtering**: Automatically excludes artists you already have and those on your exclusion lists
 - **Quality Control**: Uses MusicBrainz fuzzy matching to ensure high-quality artist data
 
@@ -105,7 +105,7 @@ Access Cmdarr at `http://localhost:8080` for:
 - **⚙️ Configuration**: Web-based configuration interface with validation
 - **🎛️ Command Management**: Enable/disable commands, view execution status, trigger manual runs
 - **📈 System Status**: Detailed system information, health metrics, and cache status
-- **🆕 New Releases**: Discover Deezer (or Spotify) releases missing from MusicBrainz; open Lidarr, MusicBrainz, or Harmony with one click
+- **🆕 New Releases**: Discover Deezer (or Spotify) releases missing from MusicBrainz; open Lidarr, MusicBrainz, or Harmony with one click. Scan Artist by URL: paste a Spotify/Deezer artist link to list all albums missing from MusicBrainz.
 
 ### Key Features
 - **Card/List View Toggle**: Switch between card view and sortable table view with localStorage persistence
@@ -155,6 +155,7 @@ Access Cmdarr at `http://localhost:8080` for:
 - 1 MusicBrainz API call per artist (release groups), no per-album lookups
 - Filters out live recordings, compilations, and guest appearances
 - One-click links to Lidarr, MusicBrainz artist page, or Harmony to add the album
+- **Scan Artist by URL**: Artist not in Lidarr yet? Paste a Spotify or Deezer artist URL to fetch all albums, compare to MusicBrainz, and get a list of missing releases with Harmony links; add each in Harmony, then add the artist to Lidarr after ~24h
 
 **Requirements**: Lidarr; either Deezer (default) or Spotify credentials in Config  
 **Configuration**: Release source in Commands → Edit; `NEW_RELEASES_CACHE_DAYS` (default 14) in Configuration → Music Sources

--- a/app/api/new_releases.py
+++ b/app/api/new_releases.py
@@ -65,7 +65,10 @@ def _album_matches_filter(
         return True
     if "album" in selected_types and album_type == "album" and total_tracks > 6:
         return True
-    if "ep" in selected_types and album_type == "album" and total_tracks <= 6:
+    # EP: Spotify uses album_type "album" + track count; Deezer uses album_type "ep"
+    if "ep" in selected_types and (
+        (album_type == "album" and total_tracks <= 6) or album_type == "ep"
+    ):
         return True
     if "single" in selected_types and album_type == "single":
         return True
@@ -582,6 +585,145 @@ async def lidarr_artists_autocomplete(
             }
             for r in rows
         ],
+    }
+
+
+def _parse_artist_url(url: str) -> tuple[Optional[str], Optional[str]]:
+    """Parse Spotify or Deezer artist URL. Returns (provider, artist_id) or (None, None)."""
+    import re
+    url = (url or "").strip()
+    if not url:
+        return None, None
+    if not url.startswith("http"):
+        url = "https://" + url
+    try:
+        from urllib.parse import urlparse
+        parsed = urlparse(url)
+        host = (parsed.netloc or "").replace("www.", "").lower()
+        path = (parsed.path or "").strip("/")
+        if host in ("open.spotify.com", "spotify.com"):
+            m = re.match(r"^(?:intl-\w{2}/)?artist/([a-zA-Z0-9]+)", path)
+            if m:
+                return "spotify", m.group(1)
+        if host == "deezer.com":
+            m = re.match(r"^(?:\w{2}/)?artist/(\d+)", path)
+            if m:
+                return "deezer", m.group(1)
+    except Exception:
+        pass
+    return None, None
+
+
+class ScanArtistUrlRequest(BaseModel):
+    url: str
+    album_types: Optional[List[str]] = None
+
+
+@router.post("/new-releases/scan-artist-url")
+async def scan_artist_url(body: ScanArtistUrlRequest):
+    """
+    Scan an artist by Spotify or Deezer artist URL. Fetches all albums, compares to
+    MusicBrainz, and returns a list of releases missing from MB with Harmony links.
+    Artist need not be in Lidarr.
+    """
+    logger = get_logger("cmdarr.api.new_releases")
+    config = ConfigAdapter()
+
+    provider, artist_id = _parse_artist_url(body.url)
+    if not provider or not artist_id:
+        raise HTTPException(
+            status_code=400,
+            detail="URL must be a Spotify or Deezer artist link (e.g. open.spotify.com/artist/... or deezer.com/artist/...)",
+        )
+
+    if provider == "spotify":
+        if not config.SPOTIFY_CLIENT_ID or not config.SPOTIFY_CLIENT_SECRET:
+            raise HTTPException(
+                status_code=503,
+                detail="Spotify credentials not configured. Use Deezer artist URL or add Spotify credentials in Config.",
+            )
+    if not config.MUSICBRAINZ_ENABLED:
+        raise HTTPException(status_code=503, detail="MusicBrainz not configured")
+
+    raw = body.album_types
+    if raw is None:
+        raw = ["album", "ep", "single"]
+    elif isinstance(raw, str):
+        raw = [t.strip() for t in raw.split(",") if t.strip()]
+    selected = {t.lower() for t in raw if t} & ALBUM_TYPES
+    if not selected:
+        selected = {"album", "ep", "single"}
+
+    client_class = SpotifyClient if provider == "spotify" else DeezerClient
+    cache_ttl = getattr(config, "NEW_RELEASES_CACHE_DAYS", 14)
+
+    try:
+        async with client_class(config) as release_client:
+            artist_info = await release_client.get_artist(artist_id)
+            if not artist_info.get("success") or not artist_info.get("name"):
+                raise HTTPException(status_code=404, detail="Artist not found")
+
+            artist_name = artist_info.get("name", "Unknown")
+
+            albums_result = await release_client.get_artist_albums(
+                artist_id,
+                limit=50,
+                include_groups="album,single,compilation,appears_on",
+                fetch_all=True,
+            )
+            if not albums_result.get("success"):
+                raise HTTPException(status_code=500, detail="Failed to fetch albums")
+
+            albums = albums_result.get("albums", [])
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception(f"Scan artist URL failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+    mb_titles: List[str] = []
+    mb_artist_mbid: Optional[str] = None
+    async with MusicBrainzClient(config) as mb_client:
+        mb_artist = await mb_client.fuzzy_search_artist(artist_name)
+        if mb_artist and mb_artist.get("mbid"):
+            mb_artist_mbid = mb_artist["mbid"]
+            mb_titles = await mb_client.get_artist_release_groups(
+                mb_artist_mbid, cache_ttl_days=cache_ttl
+            ) or []
+
+    missing = []
+    for album in albums:
+        if str(album.get("primary_artist_id", "")) != str(artist_id):
+            continue
+        album_type = album.get("album_type", "")
+        total_tracks = album.get("total_tracks", 0)
+        if not _album_matches_filter(album_type, total_tracks, selected):
+            continue
+        if _is_live_release(album.get("name", "")):
+            continue
+        album_url = album.get("spotify_url") or album.get("external_url", "")
+        if not album_url:
+            continue
+        if _title_matches_mb(album.get("name", ""), mb_titles):
+            continue
+        harmony_url = f"{HARMONY_BASE_URL}?url={quote(album_url, safe='')}"
+        missing.append({
+            "name": album.get("name", "Unknown"),
+            "release_date": album.get("release_date", ""),
+            "album_type": album_type,
+            "total_tracks": total_tracks,
+            "album_url": album_url,
+            "harmony_url": harmony_url,
+        })
+
+    return {
+        "success": True,
+        "artist_name": artist_name,
+        "artist_in_mb": mb_artist_mbid is not None,
+        "musicbrainz_artist_url": f"https://musicbrainz.org/artist/{mb_artist_mbid}" if mb_artist_mbid else None,
+        "total_albums": len(albums),
+        "missing_count": len(missing),
+        "albums": missing,
     }
 
 

--- a/clients/client_deezer.py
+++ b/clients/client_deezer.py
@@ -241,9 +241,10 @@ class DeezerClient(BaseAPIClient):
         """
         Search for artists by name on Deezer.
         Returns dict with success, artists list (id, name, link) matching Spotify shape.
+        Uses order=RATING_DESC to prioritize the most popular (likely correct) match.
         """
         try:
-            params = {'q': name, 'limit': min(limit, 25)}
+            params = {'q': name, 'limit': min(limit, 25), 'order': 'RATING_DESC'}
             result = await self._get("/search/artist", params=params)
             if not result or result.get('error'):
                 return {'success': False, 'error': 'No response from Deezer', 'artists': []}

--- a/commands/new_releases_discovery.py
+++ b/commands/new_releases_discovery.py
@@ -56,7 +56,10 @@ def _album_matches_filter(album_type: str, total_tracks: int, selected_types: Se
         return True
     if "album" in selected_types and album_type == "album" and total_tracks > 6:
         return True
-    if "ep" in selected_types and album_type == "album" and total_tracks <= 6:
+    # EP: Spotify uses album_type "album" + track count; Deezer uses album_type "ep"
+    if "ep" in selected_types and (
+        (album_type == "album" and total_tracks <= 6) or album_type == "ep"
+    ):
         return True
     if "single" in selected_types and album_type == "single":
         return True

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -10,6 +10,7 @@ import type {
   NewReleasesResponse,
   PendingReleasesResponse,
   LidarrArtistSuggestion,
+  ScanArtistUrlResponse,
   ImportListMetrics,
   LibraryCacheStatus,
 } from './types'
@@ -342,6 +343,13 @@ class ApiClient {
 
   async syncLidarrArtists(): Promise<{ success: boolean; synced?: number; updated?: number }> {
     return this.request(`/api/new-releases/sync-lidarr-artists`, { method: 'POST' })
+  }
+
+  async scanArtistUrl(params: { url: string; album_types?: string[] }): Promise<ScanArtistUrlResponse> {
+    return this.request(`/api/new-releases/scan-artist-url`, {
+      method: 'POST',
+      body: JSON.stringify(params),
+    })
   }
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -162,6 +162,25 @@ export interface PendingReleasesResponse {
   items: NewReleasePendingItem[]
 }
 
+export interface ScanArtistUrlAlbum {
+  name: string
+  release_date: string
+  album_type: string
+  total_tracks?: number
+  album_url: string
+  harmony_url: string
+}
+
+export interface ScanArtistUrlResponse {
+  success: boolean
+  artist_name: string
+  artist_in_mb: boolean
+  musicbrainz_artist_url?: string | null
+  total_albums: number
+  missing_count: number
+  albums: ScanArtistUrlAlbum[]
+}
+
 export interface LidarrArtistSuggestion {
   artist_mbid: string
   artist_name: string

--- a/frontend/src/pages/NewReleases.tsx
+++ b/frontend/src/pages/NewReleases.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import { Search, ExternalLink, Disc3, Loader2, Play, Database, EyeOff, RefreshCw, Ban } from 'lucide-react'
+import { Search, ExternalLink, Disc3, Loader2, Play, Database, EyeOff, RefreshCw, Ban, Link2 } from 'lucide-react'
 import { api } from '@/lib/api'
 import type { NewReleasePendingItem } from '@/lib/types'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -19,6 +19,16 @@ export function NewReleasesPage() {
   const [batchRunning, setBatchRunning] = useState(false)
   const [commandEnabled, setCommandEnabled] = useState(false)
   const [adHocAlbumTypes, setAdHocAlbumTypes] = useState<Set<string>>(new Set(['album']))
+  const [artistUrl, setArtistUrl] = useState('')
+  const [artistScanResult, setArtistScanResult] = useState<{
+    artist_name: string
+    artist_in_mb: boolean
+    musicbrainz_artist_url?: string | null
+    total_albums: number
+    missing_count: number
+    albums: { name: string; release_date: string; album_type: string; album_url: string; harmony_url: string }[]
+  } | null>(null)
+  const [artistScanning, setArtistScanning] = useState(false)
 
   const toggleAdHocAlbumType = (id: string) => {
     setAdHocAlbumTypes((prev) => {
@@ -187,6 +197,59 @@ export function NewReleasesPage() {
     if (url) window.open(url, '_blank', 'noopener,noreferrer')
   }
 
+  const isSpotifyOrDeezerArtistUrl = (s: string): boolean => {
+    const t = s.trim()
+    if (!t) return false
+    try {
+      const u = new URL(t.startsWith('http') ? t : `https://${t}`)
+      const host = u.hostname.replace(/^www\./, '')
+      const spotifyArtist = /^(\/intl-\w{2})?\/artist\/[\w-]+/
+      const deezerArtist = /^(\/\w{2})?\/artist\/\d+/
+      if ((host === 'open.spotify.com' || host === 'spotify.com') && spotifyArtist.test(u.pathname)) return true
+      if (host === 'deezer.com' && deezerArtist.test(u.pathname)) return true
+    } catch {
+      return false
+    }
+    return false
+  }
+  const handleScanArtistUrl = async () => {
+    const trimmed = artistUrl.trim()
+    if (!trimmed) {
+      toast.error('Paste a Spotify or Deezer artist URL')
+      return
+    }
+    const url = trimmed.startsWith('http') ? trimmed : `https://${trimmed}`
+    if (!isSpotifyOrDeezerArtistUrl(url)) {
+      toast.error('URL must be a Spotify or Deezer artist link (e.g. open.spotify.com/artist/... or deezer.com/artist/...)')
+      return
+    }
+    setArtistScanning(true)
+    setArtistScanResult(null)
+    try {
+      const res = await api.scanArtistUrl({
+        url,
+        album_types: Array.from(adHocAlbumTypes),
+      })
+      setArtistScanResult({
+        artist_name: res.artist_name,
+        artist_in_mb: res.artist_in_mb,
+        musicbrainz_artist_url: res.musicbrainz_artist_url,
+        total_albums: res.total_albums,
+        missing_count: res.missing_count,
+        albums: res.albums,
+      })
+      if (res.missing_count === 0) {
+        toast.success(`All ${res.total_albums} releases for ${res.artist_name} are already in MusicBrainz`)
+      } else {
+        toast.success(`Found ${res.missing_count} releases missing from MusicBrainz`)
+      }
+    } catch (err: any) {
+      toast.error(err?.message || 'Scan failed')
+    } finally {
+      setArtistScanning(false)
+    }
+  }
+
   return (
     <div className="space-y-6">
       <div>
@@ -195,6 +258,83 @@ export function NewReleasesPage() {
           Find releases on Deezer (or Spotify) from your Lidarr artists that are missing from MusicBrainz.
         </p>
       </div>
+
+      {/* Scan artist by URL: Artist not in Lidarr? Compare all albums to MusicBrainz */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Link2 className="h-5 w-5" />
+            Scan Artist by URL
+          </CardTitle>
+          <CardDescription>
+            Artist not in Lidarr yet? Paste a Spotify or Deezer artist URL to fetch all albums, compare to MusicBrainz, and get a list of missing releases with Harmony links. Add each in Harmony, then add the artist to Lidarr after ~24h.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex flex-wrap gap-2">
+            <Input
+              placeholder="https://open.spotify.com/artist/... or https://deezer.com/artist/..."
+              value={artistUrl}
+              onChange={(e) => setArtistUrl(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && handleScanArtistUrl()}
+              className="flex-1 min-w-[280px]"
+            />
+            <Button onClick={handleScanArtistUrl} disabled={!artistUrl.trim() || artistScanning}>
+              {artistScanning ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Search className="mr-2 h-4 w-4" />}
+              Scan for missing releases
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Uses release types from Actions below (album, ep, single, other).
+          </p>
+          {artistScanResult && (
+            <div className="space-y-3 rounded-lg border bg-muted/30 p-4">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div>
+                  <span className="font-medium">{artistScanResult.artist_name}</span>
+                  <span className="ml-2 text-sm text-muted-foreground">
+                    {artistScanResult.missing_count} of {artistScanResult.total_albums} releases missing from MusicBrainz
+                    {artistScanResult.artist_in_mb ? '' : ' (artist not in MB yet)'}
+                  </span>
+                </div>
+                {artistScanResult.musicbrainz_artist_url && (
+                  <Button variant="outline" size="sm" asChild>
+                    <a href={artistScanResult.musicbrainz_artist_url} target="_blank" rel="noopener noreferrer">
+                      MusicBrainz
+                    </a>
+                  </Button>
+                )}
+              </div>
+              {artistScanResult.albums.length > 0 ? (
+                <div className="space-y-2 max-h-[320px] overflow-y-auto">
+                  {artistScanResult.albums.map((a, i) => (
+                    <div
+                      key={i}
+                      className="flex flex-wrap items-center justify-between gap-2 rounded border bg-background px-3 py-2"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <span>{a.name}</span>
+                        {a.album_type && (
+                          <span className="ml-2 text-xs text-muted-foreground capitalize">{a.album_type}</span>
+                        )}
+                        {a.release_date && (
+                          <span className="ml-2 text-sm text-muted-foreground">{a.release_date}</span>
+                        )}
+                      </div>
+                      <Button variant="outline" size="sm" onClick={() => openHarmony(a.harmony_url)}>
+                        <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
+                        Add to MB
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground">All releases are already in MusicBrainz.</p>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
 
       {/* Actions: Run batch, Sync Lidarr, Search artist */}
       <Card>


### PR DESCRIPTION
- Scan Artist by URL: paste Spotify/Deezer artist link to list all albums missing from MusicBrainz with Harmony links (replaces single-album Quick Add)
- Deezer EP filter fix: include album_type 'ep' (Deezer uses record_type ep, Spotify uses album + track count)
- Deezer artist search: add order=RATING_DESC for better match ranking

Made-with: Cursor