### PR TITLE
Release/0.3.8

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,7 +18,26 @@ env:
   IMAGE_NAME: devianteng/cmdarr
 
 jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+
+      - name: Run unit tests
+        run: pytest tests/ -v
+
   build-and-push:
+    needs: [unit-tests]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.8-dev] - TBD
+## [0.3.8] - 2026-03-09
 
 ### 🧪 Unit Tests & CI
 - **Unit Tests**: pytest-based tests in `tests/`; start with `parse_playlist_url` (Spotify, Deezer, invalid URLs)
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Feb 2026 API Migration**: Playlist `/items` endpoint, search limit 10, field renames for Development Mode compatibility
 - **Execution Failure Fix**: API errors (403, etc.) now correctly mark execution as failed with error message in UI
 - **NRD**: Grey out Spotify source when credentials not configured; `new-releases-sources` endpoint for UI
+- **NRD Save Validation**: When saving with Spotify source, test API connectivity; reject save if 403 Premium required (prompts use Deezer instead)
+- **Test Connectivity**: Spotify "Not configured" shows as warning (orange) instead of error (red)
 
 ### 📚 Library Selector – Single Source of Truth
 - **Shared Utility**: `utils/library_selector.py` – resolution logic for Plex and Jellyfin; used by all commands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.8-dev] - Unreleased
+
+### 🎵 Artist Discovery Guardrail
+- **Max per run**: Per-command limit (default 2) for how many new artists are added to the Playlist Sync Discovery import list per sync run; configurable in create/edit when "Add new artists" is enabled
+- **First run**: No artists added on first run—only reports count in execution history; subsequent runs add per limit
+- **Always report**: Discovery runs on every successful sync; execution history shows "X new artists detected" regardless of whether adding is enabled
+- **UI rename**: Checkbox renamed from "Enable artist discovery" to "Add new artists" with clearer description—discovery always runs to report counts; checkbox controls whether to add to import list
+
 ## [0.3.8] - 2026-03-05
 
 ### 📚 Library Selector – Single Source of Truth

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.8] - 2026-03-05
+## [0.3.8-dev] - TBD
 
 ### 📚 Library Selector – Single Source of Truth
 - **Shared Utility**: `utils/library_selector.py` – resolution logic for Plex and Jellyfin; used by all commands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.8-dev] - Unreleased
-
-### 🎵 Artist Discovery Guardrail
-- **Max per run**: Per-command limit (default 2) for how many new artists are added to the Playlist Sync Discovery import list per sync run; configurable in create/edit when "Add new artists" is enabled
-- **First run**: No artists added on first run—only reports count in execution history; subsequent runs add per limit
-- **Always report**: Discovery runs on every successful sync; execution history shows "X new artists detected" regardless of whether adding is enabled
-- **UI rename**: Checkbox renamed from "Enable artist discovery" to "Add new artists" with clearer description—discovery always runs to report counts; checkbox controls whether to add to import list
-
-## [0.3.8] - 2026-03-05
+## [0.3.8-dev] - TBD
 
 ### 📚 Library Selector – Single Source of Truth
 - **Shared Utility**: `utils/library_selector.py` – resolution logic for Plex and Jellyfin; used by all commands
@@ -26,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Clients**: Plex and Jellyfin clients delegate to `resolve_plex_library()` / `resolve_jellyfin_library()`; removed duplicated `_resolve_music_library` and `_first_by_lowest_key`
 - **Library Cache Builder**: Uses shared utility; re-resolves and updates cached key on each run
 - **Daylist**: Simplified to `get_resolved_library()` instead of direct `_resolve_music_library` call
+
+### 🎵 Artist Discovery Guardrail
+- **Max per run**: Per-command limit (default 2) for how many new artists are added to the Playlist Sync Discovery import list per sync run; configurable in create/edit when "Add new artists" is enabled
+- **First run**: No artists added on first run—only reports count in execution history; subsequent runs add per limit
+- **Always report**: Discovery runs on every successful sync; execution history shows "X new artists detected" regardless of whether adding is enabled
+- **UI rename**: Checkbox renamed from "Enable artist discovery" to "Add new artists" with clearer description—discovery always runs to report counts; checkbox controls whether to add to import list
 
 ## [0.3.7] - 2026-03-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.8] - 2026-03-05
+
+### 📚 Library Selector – Single Source of Truth
+- **Shared Utility**: `utils/library_selector.py` – resolution logic for Plex and Jellyfin; used by all commands
+- **Resolution Order**: `PLEX_LIBRARY_NAME` / `JELLYFIN_LIBRARY_NAME` if set; else prefer "Music"; else first by lowest key (type=artist)
+- **Cached Keys**: `PLEX_LIBRARY_KEY` and `JELLYFIN_LIBRARY_KEY` (hidden, auto-managed) – resolved on startup and when library cache builder runs
+- **Consistent Usage**: Library cache, play history, track/artist search, sonic analysis all use the resolved library
+- **No Fallback to Stale**: Commands no longer use stored `target_library_key` from create; always resolve or use cached key
+
+### 🔧 Refactor
+- **Clients**: Plex and Jellyfin clients delegate to `resolve_plex_library()` / `resolve_jellyfin_library()`; removed duplicated `_resolve_music_library` and `_first_by_lowest_key`
+- **Library Cache Builder**: Uses shared utility; re-resolves and updates cached key on each run
+- **Daylist**: Simplified to `get_resolved_library()` instead of direct `_resolve_music_library` call
+
 ## [0.3.7] - 2026-03-05
 
 ### 🎵 New Playlist Generators

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.8-dev] - TBD
 
+### 🧪 Unit Tests & CI
+- **Unit Tests**: pytest-based tests in `tests/`; start with `parse_playlist_url` (Spotify, Deezer, invalid URLs)
+- **CI Gate**: `docker-publish` workflow runs unit tests before Docker build; build fails if tests fail
+- **Dev Dependencies**: `requirements-dev.txt` adds pytest and pytest-asyncio
+
+### 🎵 Spotify Scraper Fallback
+- **Credential-Based Logic**: Use API when credentials configured; fall back to SpotifyScraper when not configured or API fails (e.g. 403 Premium required)
+- **Public Playlists Only**: Scraper and API both support public playlists; no OAuth/private playlist support
+- **Feb 2026 API Migration**: Playlist `/items` endpoint, search limit 10, field renames for Development Mode compatibility
+- **Execution Failure Fix**: API errors (403, etc.) now correctly mark execution as failed with error message in UI
+- **NRD**: Grey out Spotify source when credentials not configured; `new-releases-sources` endpoint for UI
+
 ### 📚 Library Selector – Single Source of Truth
 - **Shared Utility**: `utils/library_selector.py` – resolution logic for Plex and Jellyfin; used by all commands
 - **Resolution Order**: `PLEX_LIBRARY_NAME` / `JELLYFIN_LIBRARY_NAME` if set; else prefer "Music"; else first by lowest key (type=artist)

--- a/__version__.py
+++ b/__version__.py
@@ -2,4 +2,4 @@
 Cmdarr version information
 """
 
-__version__ = "0.3.8-dev"
+__version__ = "0.3.8"

--- a/__version__.py
+++ b/__version__.py
@@ -2,4 +2,4 @@
 Cmdarr version information
 """
 
-__version__ = "0.3.7"
+__version__ = "0.3.8"

--- a/__version__.py
+++ b/__version__.py
@@ -2,4 +2,4 @@
 Cmdarr version information
 """
 
-__version__ = "0.3.8"
+__version__ = "0.3.8-dev"

--- a/app/api/commands.py
+++ b/app/api/commands.py
@@ -1392,6 +1392,7 @@ async def create_external_playlist_sync(request: dict, db: Session = Depends(get
 
         # Create command config
         try:
+            enable_artist_discovery = request.get("enable_artist_discovery", False)
             config_json = {
                 "source": source,
                 "unique_id": f"{next_id:05d}",
@@ -1399,7 +1400,10 @@ async def create_external_playlist_sync(request: dict, db: Session = Depends(get
                 "playlist_name": playlist_name,
                 "target": target,
                 "sync_mode": sync_mode,
-                "enable_artist_discovery": request.get("enable_artist_discovery", False),
+                "enable_artist_discovery": enable_artist_discovery,
+                "artist_discovery_max_per_run": request.get("artist_discovery_max_per_run", 2)
+                if enable_artist_discovery
+                else 0,
             }
             if request.get("expires_at"):
                 config_json["expires_at"] = request.get("expires_at")
@@ -1563,6 +1567,7 @@ async def create_listenbrainz_playlist_sync(request: dict, db: Session = Depends
 
         # Create command config
         try:
+            enable_artist_discovery = request.get("enable_artist_discovery", False)
             config_json = {
                 "source": "listenbrainz",
                 "unique_id": f"{next_id:05d}",
@@ -1573,7 +1578,10 @@ async def create_listenbrainz_playlist_sync(request: dict, db: Session = Depends
                 "weekly_jams_keep": weekly_jams_keep,
                 "daily_jams_keep": daily_jams_keep,
                 "cleanup_enabled": cleanup_enabled,
-                "enable_artist_discovery": request.get("enable_artist_discovery", False),
+                "enable_artist_discovery": enable_artist_discovery,
+                "artist_discovery_max_per_run": request.get("artist_discovery_max_per_run", 2)
+                if enable_artist_discovery
+                else 0,
             }
             if request.get("expires_at"):
                 config_json["expires_at"] = request.get("expires_at")

--- a/app/api/commands.py
+++ b/app/api/commands.py
@@ -1703,6 +1703,38 @@ async def delete_command(command_name: str, db: Annotated[Session, Depends(get_c
         raise HTTPException(status_code=500, detail="Failed to delete command")
 
 
+@router.get("/new-releases-sources")
+async def get_new_releases_sources():
+    """Get available New Releases Discovery sources and their configuration status"""
+    try:
+        from commands.config_adapter import Config
+
+        config = Config()
+
+        sources = [
+            {
+                "id": "deezer",
+                "name": "Deezer",
+                "configured": True,
+                "config_help": "No account required—uses public data",
+            },
+            {
+                "id": "spotify",
+                "name": "Spotify",
+                "configured": bool(config.SPOTIFY_CLIENT_ID and config.SPOTIFY_CLIENT_SECRET),
+                "config_help": "Requires credentials in Config → Music Sources",
+            },
+        ]
+
+        return {"sources": sources}
+
+    except Exception as e:
+        get_commands_logger().error(f"Failed to get new releases sources: {e}")
+        raise HTTPException(
+            status_code=500, detail="Failed to get new releases sources"
+        )
+
+
 @router.get("/playlist-sync/sources")
 async def get_playlist_sync_sources():
     """Get available playlist sync sources and their configuration status"""
@@ -1718,7 +1750,7 @@ async def get_playlist_sync_sources():
                 "requires_url": True,
                 "example_url": "https://open.spotify.com/playlist/4NDXWHwYWjFmgVPkNy4YlF",
                 "configured": bool(config.SPOTIFY_CLIENT_ID and config.SPOTIFY_CLIENT_SECRET),
-                "config_help": "Add Spotify Client ID and Secret in Settings",
+                "config_help": "For public playlists; optional—scraper used when not configured",
             },
             {
                 "id": "deezer",

--- a/app/api/commands.py
+++ b/app/api/commands.py
@@ -910,18 +910,14 @@ async def create_local_discovery(request: dict, db: Annotated[Session, Depends(g
         from commands.config_adapter import Config
 
         config = Config()
-        library_key = getattr(config, "PLEX_LIBRARY_KEY", None)
-        if not library_key:
-            from clients.client_plex import PlexClient
+        from clients.client_plex import PlexClient
 
-            pc = PlexClient(config)
-            libs = pc.get_music_libraries()
-            if libs:
-                library_key = libs[0].get("key")
+        pc = PlexClient(config)
+        library_key = pc.get_resolved_library_key()
         if not library_key:
             raise HTTPException(
                 status_code=400,
-                detail="Could not resolve Plex library. Configure PLEX_LIBRARY_KEY.",
+                detail="Could not resolve Plex library. Configure PLEX_LIBRARY_NAME or add a music library.",
             )
 
         config_json = {
@@ -1032,28 +1028,21 @@ async def create_top_tracks(request: dict, db: Annotated[Session, Depends(get_co
 
         config = Config()
         library_key = None
-        if target == "plex" and hasattr(config, "PLEX_LIBRARY_KEY"):
-            library_key = getattr(config, "PLEX_LIBRARY_KEY", None)
-        if not library_key and target == "plex":
+        if target == "plex":
             from clients.client_plex import PlexClient
 
             pc = PlexClient(config)
-            libs = pc.get_music_libraries()
-            if libs:
-                library_key = libs[0].get("key")
-
-        if target == "jellyfin":
+            library_key = pc.get_resolved_library_key()
+        elif target == "jellyfin":
             from clients.client_jellyfin import JellyfinClient
 
             jc = JellyfinClient(config)
-            libs = jc.get_music_libraries()
-            if libs:
-                library_key = libs[0].get("Id") or libs[0].get("key")
+            library_key = jc.get_resolved_library_key()
 
         if not library_key:
             raise HTTPException(
                 status_code=400,
-                detail="Could not resolve target library. Configure PLEX_LIBRARY_KEY or add a music library.",
+                detail="Could not resolve target library. Configure PLEX_LIBRARY_NAME or JELLYFIN_LIBRARY_NAME, or add a music library.",
             )
 
         existing = (
@@ -1171,21 +1160,14 @@ async def create_mood_playlist(request: dict, db: Annotated[Session, Depends(get
         from commands.config_adapter import Config
 
         config = Config()
-        library_key = None
-        if hasattr(config, "PLEX_LIBRARY_KEY"):
-            library_key = getattr(config, "PLEX_LIBRARY_KEY", None)
-        if not library_key:
-            from clients.client_plex import PlexClient
+        from clients.client_plex import PlexClient
 
-            pc = PlexClient(config)
-            libs = pc.get_music_libraries()
-            if libs:
-                library_key = libs[0].get("key")
-
+        pc = PlexClient(config)
+        library_key = pc.get_resolved_library_key()
         if not library_key:
             raise HTTPException(
                 status_code=400,
-                detail="Could not resolve Plex library. Configure PLEX_LIBRARY_KEY or add a music library.",
+                detail="Could not resolve Plex library. Configure PLEX_LIBRARY_NAME or add a music library.",
             )
 
         existing = (

--- a/app/api/commands.py
+++ b/app/api/commands.py
@@ -317,10 +317,11 @@ async def update_command(
         if request.timeout_minutes is not None:
             command.timeout_minutes = request.timeout_minutes
         if request.config_json is not None:
-            # Validate Spotify credentials when switching NRD to Spotify source
+            # Validate Spotify credentials and API access when switching NRD to Spotify source
             if command_name == "new_releases_discovery":
                 src = (request.config_json.get("new_releases_source") or "deezer").strip().lower()
                 if src == "spotify":
+                    from clients.client_spotify import SpotifyClient
                     from commands.config_adapter import ConfigAdapter
 
                     config = ConfigAdapter()
@@ -329,6 +330,17 @@ async def update_command(
                             status_code=400,
                             detail="Spotify credentials must be set in Config → Music Sources before using Spotify as the release source.",
                         )
+                    # Verify API actually works (e.g. not 403 Premium required)
+                    client = SpotifyClient(config)
+                    try:
+                        connected = await client.test_connection()
+                        if not connected:
+                            raise HTTPException(
+                                status_code=400,
+                                detail="Spotify API requires Premium for Development Mode. Use Deezer as the release source instead.",
+                            )
+                    finally:
+                        await client.close()
             command.config_json = request.config_json
             # display_name for top_tracks is updated by the command when it runs (matches playlist title)
 
@@ -1730,9 +1742,7 @@ async def get_new_releases_sources():
 
     except Exception as e:
         get_commands_logger().error(f"Failed to get new releases sources: {e}")
-        raise HTTPException(
-            status_code=500, detail="Failed to get new releases sources"
-        )
+        raise HTTPException(status_code=500, detail="Failed to get new releases sources")
 
 
 @router.get("/playlist-sync/sources")

--- a/app/api/test_connectivity.py
+++ b/app/api/test_connectivity.py
@@ -407,7 +407,7 @@ async def _test_spotify() -> ConnectivityTestResult:
                 success=False,
                 message="Not configured",
                 error="Spotify Client ID or Client Secret not set",
-                status="error",
+                status="warning",
             )
 
         # Test connection

--- a/app/main.py
+++ b/app/main.py
@@ -130,6 +130,55 @@ def auto_enable_library_cache():
         # Non-fatal, continue startup
 
 
+def resolve_library_keys_on_startup():
+    """Resolve and cache PLEX_LIBRARY_KEY and JELLYFIN_LIBRARY_KEY for enabled clients."""
+    try:
+        from commands.config_adapter import Config
+
+        config = Config()
+        # Plex
+        if (
+            config.get("PLEX_CLIENT_ENABLED", False)
+            and config.get("PLEX_URL")
+            and config.get("PLEX_TOKEN")
+        ):
+            try:
+                from clients.client_plex import PlexClient
+                from utils.library_selector import resolve_plex_library
+
+                pc = PlexClient(config)
+                chosen = resolve_plex_library(pc)
+                if chosen and chosen.get("key"):
+                    config_service.set("PLEX_LIBRARY_KEY", str(chosen["key"]))
+                    get_app_logger().info(
+                        f"Resolved Plex library: {chosen.get('title', '?')} (key={chosen['key']})"
+                    )
+            except Exception as e:
+                get_app_logger().warning(f"Could not resolve Plex library on startup: {e}")
+        # Jellyfin
+        if (
+            config.get("JELLYFIN_CLIENT_ENABLED", False)
+            and config.get("JELLYFIN_URL")
+            and config.get("JELLYFIN_TOKEN")
+            and config.get("JELLYFIN_USER_ID")
+        ):
+            try:
+                from clients.client_jellyfin import JellyfinClient
+                from utils.library_selector import resolve_jellyfin_library
+
+                jc = JellyfinClient(config)
+                chosen = resolve_jellyfin_library(jc)
+                if chosen and chosen.get("key"):
+                    config_service.set("JELLYFIN_LIBRARY_KEY", str(chosen["key"]))
+                    get_app_logger().info(
+                        f"Resolved Jellyfin library: {chosen.get('title', '?')} (key={chosen['key']})"
+                    )
+            except Exception as e:
+                get_app_logger().warning(f"Could not resolve Jellyfin library on startup: {e}")
+    except Exception as e:
+        get_app_logger().warning(f"Library key resolution on startup failed: {e}")
+
+
 def trigger_immediate_cache_build():
     """Trigger immediate cache build when auto-enabled"""
     try:
@@ -188,6 +237,14 @@ async def lifespan(app: FastAPI):
         get_app_logger().info("Auto-enable library cache check completed")
     except Exception as e:
         get_app_logger().error(f"Failed to auto-enable library cache: {e}")
+        # Don't raise here as the app can still work
+
+    # Resolve and cache library keys for Plex/Jellyfin (PLEX_LIBRARY_KEY, JELLYFIN_LIBRARY_KEY)
+    try:
+        resolve_library_keys_on_startup()
+        get_app_logger().info("Library key resolution completed")
+    except Exception as e:
+        get_app_logger().error(f"Failed to resolve library keys: {e}")
         # Don't raise here as the app can still work
 
     # Clean up stuck commands from previous runs and queue retries for interrupted commands

--- a/clients/client_jellyfin.py
+++ b/clients/client_jellyfin.py
@@ -12,7 +12,9 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 from cache_manager import get_cache_manager
+from services.config_service import config_service
 from utils.cache_client import create_cache_client
+from utils.library_selector import resolve_jellyfin_library
 
 from .client_base import BaseAPIClient
 
@@ -67,11 +69,22 @@ class JellyfinClient(BaseAPIClient):
         session.mount("https://", adapter)
         return session
 
+    def get_resolved_library(self) -> dict[str, Any] | None:
+        """Return the resolved music library dict for cache, playlist sync, and search. Single library only."""
+        return resolve_jellyfin_library(self)
+
     def get_resolved_library_key(self) -> str | None:
         """Return the resolved music library key for cache, playlist sync, and search. Single library only."""
-        music_libraries = self.get_music_libraries()
-        chosen = self._resolve_music_library(music_libraries)
-        return chosen["key"] if chosen else None
+        cached = (self.config.get("JELLYFIN_LIBRARY_KEY") or "").strip()
+        if cached:
+            return cached
+        chosen = resolve_jellyfin_library(self)
+        if chosen:
+            key = str(chosen.get("key", ""))
+            if key:
+                config_service.set("JELLYFIN_LIBRARY_KEY", key)
+                return key
+        return None
 
     def get_cache_key(self, library_key: str = None) -> str:
         """Generate cache key for library cache"""
@@ -84,10 +97,9 @@ class JellyfinClient(BaseAPIClient):
         if library_key:
             return f"jellyfin:{base_url}:library:{library_key}"
         try:
-            music_libraries = self.get_music_libraries()
-            chosen = self._resolve_music_library(music_libraries)
-            if chosen:
-                return f"jellyfin:{base_url}:library:{chosen['key']}"
+            resolved = self.get_resolved_library_key()
+            if resolved:
+                return f"jellyfin:{base_url}:library:{resolved}"
         except Exception:
             pass
         return f"jellyfin:{base_url}:library:default"
@@ -1646,46 +1658,6 @@ class JellyfinClient(BaseAPIClient):
             self.logger.error(f"Error getting music libraries: {e}")
             return []
 
-    def _resolve_music_library(
-        self, music_libraries: list[dict[str, Any]]
-    ) -> dict[str, Any] | None:
-        """Resolve which music library to use (single library only).
-        - If JELLYFIN_LIBRARY_NAME set: use that by name (case-insensitive)
-        - If blank and only 1 library: use it
-        - If multiple: prefer one named 'Music' (case-insensitive)
-        - Else: use first (lowest library key/id)"""
-        if not music_libraries:
-            return None
-        name_override = (self.config.get("JELLYFIN_LIBRARY_NAME") or "").strip()
-        if name_override:
-            for lib in music_libraries:
-                if (lib.get("title") or "").strip().lower() == name_override.lower():
-                    return lib
-            self.logger.warning(
-                f"Library '{name_override}' not found in {[item.get('title') for item in music_libraries]}, using first"
-            )
-            return self._first_by_lowest_key(music_libraries)
-        if len(music_libraries) == 1:
-            return music_libraries[0]
-        for lib in music_libraries:
-            if (lib.get("title") or "").strip().lower() == "music":
-                return lib
-        return self._first_by_lowest_key(music_libraries)
-
-    def _first_by_lowest_key(self, libraries: list[dict[str, Any]]) -> dict[str, Any] | None:
-        """Return library with lowest key (numeric when possible, else string)."""
-        if not libraries:
-            return None
-
-        def sort_key(lib):
-            k = lib.get("key") or ""
-            try:
-                return (0, int(k))
-            except ValueError, TypeError:
-                return (1, str(k))
-
-        return min(libraries, key=sort_key)
-
     def build_library_cache(self, library_key: str = None) -> dict[str, Any]:
         """
         Build optimized library cache for Jellyfin music library
@@ -1702,8 +1674,7 @@ class JellyfinClient(BaseAPIClient):
         try:
             # Resolve library (same logic as Plex - single library only)
             if not library_key:
-                music_libraries = self.get_music_libraries()
-                chosen = self._resolve_music_library(music_libraries)
+                chosen = resolve_jellyfin_library(self)
                 if chosen:
                     library_key = chosen["key"]
                     self.logger.info(f"Using music library: {chosen['title']}")

--- a/clients/client_plex.py
+++ b/clients/client_plex.py
@@ -15,7 +15,9 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 from cache_manager import get_cache_manager
+from services.config_service import config_service
 from utils.cache_client import create_cache_client
+from utils.library_selector import resolve_plex_library
 
 from .client_base import BaseAPIClient
 
@@ -77,25 +79,34 @@ class PlexClient(BaseAPIClient):
     # ==== LIBRARY CACHE INTERFACE METHODS ====
     # Required by LibraryCacheManager for optimization
 
+    def get_resolved_library(self) -> dict[str, Any] | None:
+        """Return the resolved music library dict for cache, playlist sync, and search. Single library only."""
+        return resolve_plex_library(self)
+
     def get_resolved_library_key(self) -> str | None:
         """Return the resolved music library key for cache, playlist sync, and search. Single library only."""
-        music_libraries = self.get_music_libraries()
-        chosen = self._resolve_music_library(music_libraries)
-        return chosen["key"] if chosen else None
+        cached = (self.config.get("PLEX_LIBRARY_KEY") or "").strip()
+        if cached:
+            return cached
+        chosen = resolve_plex_library(self)
+        if chosen:
+            key = str(chosen.get("key", ""))
+            if key:
+                config_service.set("PLEX_LIBRARY_KEY", key)
+                return key
+        return None
 
     def get_cache_key(self, library_key: str = None) -> str:
         """Generate cache key for library cache"""
         if library_key:
             return f"plex:{self.base_url}:library:{library_key}"
-        else:
-            try:
-                music_libraries = self.get_music_libraries()
-                chosen = self._resolve_music_library(music_libraries)
-                if chosen:
-                    return f"plex:{self.base_url}:library:{chosen['key']}"
-            except Exception:
-                pass
-            return f"plex:{self.base_url}:library:default"
+        try:
+            resolved = self.get_resolved_library_key()
+            if resolved:
+                return f"plex:{self.base_url}:library:{resolved}"
+        except Exception:
+            pass
+        return f"plex:{self.base_url}:library:default"
 
     def get_cache_ttl(self) -> int:
         """Get cache TTL in days for Plex library cache"""
@@ -117,8 +128,7 @@ class PlexClient(BaseAPIClient):
         try:
             # Get target library
             if not library_key:
-                music_libraries = self.get_music_libraries()
-                chosen = self._resolve_music_library(music_libraries)
+                chosen = resolve_plex_library(self)
                 if not chosen:
                     self.logger.error("No music libraries found for cache building")
                     return {}
@@ -638,8 +648,7 @@ class PlexClient(BaseAPIClient):
         Live API search using mediaQuery on /all (fallback when cache unavailable).
         Tries artist+track, track-only, artist-only, and partial track strategies.
         """
-        music_libraries = self.get_music_libraries()
-        chosen = self._resolve_music_library(music_libraries)
+        chosen = resolve_plex_library(self)
         if not chosen:
             self.logger.warning("No music libraries found")
             return None
@@ -1108,46 +1117,6 @@ class PlexClient(BaseAPIClient):
                 return element.text.strip()
 
         return result
-
-    def _resolve_music_library(
-        self, music_libraries: list[dict[str, Any]]
-    ) -> dict[str, Any] | None:
-        """Resolve which music library to use (single library only).
-        - If PLEX_LIBRARY_NAME set: use that by name (case-insensitive)
-        - If blank and only 1 library: use it
-        - If multiple: prefer one named 'Music' (case-insensitive)
-        - Else: use first (lowest library key/id)"""
-        if not music_libraries:
-            return None
-        name_override = (self.config.get("PLEX_LIBRARY_NAME") or "").strip()
-        if name_override:
-            for lib in music_libraries:
-                if (lib.get("title") or "").strip().lower() == name_override.lower():
-                    return lib
-            self.logger.warning(
-                f"Library '{name_override}' not found in {[item.get('title') for item in music_libraries]}, using first"
-            )
-            return self._first_by_lowest_key(music_libraries)
-        if len(music_libraries) == 1:
-            return music_libraries[0]
-        for lib in music_libraries:
-            if (lib.get("title") or "").strip().lower() == "music":
-                return lib
-        return self._first_by_lowest_key(music_libraries)
-
-    def _first_by_lowest_key(self, libraries: list[dict[str, Any]]) -> dict[str, Any] | None:
-        """Return library with lowest key (numeric when possible)."""
-        if not libraries:
-            return None
-
-        def sort_key(lib):
-            k = lib.get("key") or ""
-            try:
-                return (0, int(k))
-            except ValueError, TypeError:
-                return (1, str(k))
-
-        return min(libraries, key=sort_key)
 
     def get_music_libraries(self):
         """Get all music library sections - copied from proven working implementation"""

--- a/clients/client_plex.py
+++ b/clients/client_plex.py
@@ -1294,9 +1294,12 @@ class PlexClient(BaseAPIClient):
         track_rating_key: str | int,
         limit: int = 50,
         max_distance: float = 0.25,
+        library_key: str | None = None,
     ) -> list[dict[str, Any]]:
-        """Get sonically similar tracks for a given track. Used by daylist.
-        Returns list of track metadata dicts with ratingKey, distance, etc."""
+        """Get sonically similar tracks for a given track. Used by daylist, local discovery.
+        Returns list of track metadata dicts with ratingKey, distance, etc.
+        If library_key is provided, filters results to only tracks from that library
+        (avoids mixing Music and Audiobook when multiple music-type libraries exist)."""
         try:
             params = {"limit": limit, "maxDistance": max_distance}
             results = self._get(
@@ -1307,6 +1310,12 @@ class PlexClient(BaseAPIClient):
             metadata = media_container.get("Metadata", [])
             if not isinstance(metadata, list):
                 metadata = [metadata] if metadata else []
+            if library_key:
+                # Filter to only tracks from the target library (avoids mixing Music + Audiobook)
+                lib_key_str = str(library_key)
+                metadata = [
+                    m for m in metadata if str(m.get("librarySectionID", "")) == lib_key_str
+                ]
             return metadata
         except Exception as e:
             self.logger.error(f"Error getting sonically similar for {track_rating_key}: {e}")

--- a/clients/client_spotify.py
+++ b/clients/client_spotify.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """
 Spotify API Client
-Handles authentication and playlist operations for Spotify
+Handles authentication and playlist operations for Spotify.
+Uses API when credentials configured; falls back to SpotifyScraper when not configured or API fails.
 """
 
+import asyncio
 import base64
 import time
 from typing import Any
@@ -13,6 +15,56 @@ import aiohttp
 from utils.playlist_parser import parse_playlist_url
 
 from .client_base import BaseAPIClient
+
+
+def _scraper_get_playlist(url: str) -> dict[str, Any]:
+    """Sync helper: fetch playlist via SpotifyScraper (no auth). Returns normalized dict."""
+    from utils.text_normalizer import normalize_text
+
+    try:
+        from spotify_scraper import SpotifyClient as ScraperClient
+
+        client = ScraperClient(browser_type="requests")
+        try:
+            data = client.get_playlist_info(url)
+            tracks = []
+            for t in data.get("tracks", []):
+                artists = t.get("artists", [])
+                artist_name = (
+                    artists[0].get("name", "Unknown Artist") if artists else "Unknown Artist"
+                )
+                album = t.get("album", {}) or {}
+                album_name = (
+                    album.get("name", "Unknown Album")
+                    if isinstance(album, dict)
+                    else "Unknown Album"
+                )
+                tracks.append(
+                    {
+                        "artist": normalize_text(artist_name),
+                        "track": normalize_text(t.get("name", "Unknown Track")),
+                        "album": normalize_text(album_name),
+                    }
+                )
+            owner = data.get("owner", {}) or {}
+            owner_name = (
+                owner.get("display_name", owner.get("id", "Unknown"))
+                if isinstance(owner, dict)
+                else "Unknown"
+            )
+            return {
+                "success": True,
+                "name": data.get("name", "Unknown Playlist"),
+                "description": data.get("description", ""),
+                "owner": owner_name,
+                "track_count": len(tracks),
+                "tracks": tracks,
+                "total_tracks": len(tracks),
+            }
+        finally:
+            client.close()
+    except Exception as e:
+        return {"success": False, "error": f"Scraper failed: {str(e)}"}
 
 
 class SpotifyClient(BaseAPIClient):
@@ -34,6 +86,15 @@ class SpotifyClient(BaseAPIClient):
 
         if not self.client_id or not self.client_secret:
             self.logger.warning("Spotify credentials not configured")
+
+    def _has_credentials(self) -> bool:
+        """True if Client ID and Secret are configured."""
+        return bool(self.client_id and self.client_secret)
+
+    async def _get_playlist_via_scraper(self, url: str) -> dict[str, Any]:
+        """Run sync scraper in executor."""
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, _scraper_get_playlist, url)
 
     async def _get_access_token(self) -> bool:
         """Get Spotify access token using Client Credentials flow"""
@@ -103,47 +164,77 @@ class SpotifyClient(BaseAPIClient):
 
     async def get_playlist_info(self, url: str) -> dict[str, Any]:
         """
-        Get playlist metadata from Spotify URL
-
-        Args:
-            url: Spotify playlist URL
-
-        Returns:
-            Dict with playlist metadata or error info
+        Get playlist metadata from Spotify URL.
+        Uses API when credentials configured; falls back to scraper when not or on API failure.
         """
         try:
-            # Parse URL to get playlist ID
             parsed = parse_playlist_url(url)
             if not parsed["valid"]:
                 return {"success": False, "error": parsed["error"]}
 
-            playlist_id = parsed["playlist_id"]
+            if not self._has_credentials():
+                scraper_result = await self._get_playlist_via_scraper(url)
+                if scraper_result.get("success"):
+                    return {
+                        "success": True,
+                        "name": scraper_result.get("name", "Unknown Playlist"),
+                        "description": scraper_result.get("description", ""),
+                        "owner": scraper_result.get("owner", "Unknown"),
+                        "track_count": scraper_result.get("track_count", 0),
+                        "playlist_id": parsed["playlist_id"],
+                        "public": True,
+                        "collaborative": False,
+                    }
+                return scraper_result
 
-            # Fetch playlist info from Spotify
-            return await self._get_playlist_info_async(playlist_id)
+            api_result = await self._get_playlist_info_async(parsed["playlist_id"])
+            if api_result.get("success"):
+                return api_result
+            self.logger.info("API failed, falling back to scraper")
+            scraper_result = await self._get_playlist_via_scraper(url)
+            if scraper_result.get("success"):
+                return {
+                    "success": True,
+                    "name": scraper_result.get("name", "Unknown Playlist"),
+                    "description": scraper_result.get("description", ""),
+                    "owner": scraper_result.get("owner", "Unknown"),
+                    "track_count": scraper_result.get("track_count", 0),
+                    "playlist_id": parsed["playlist_id"],
+                    "public": True,
+                    "collaborative": False,
+                }
+            return scraper_result
 
         except Exception as e:
             self.logger.error(f"Error getting playlist info: {e}")
             return {"success": False, "error": "Failed to fetch playlist info"}
 
     async def _get_playlist_info_async(self, playlist_id: str) -> dict[str, Any]:
-        """Async helper to get playlist info"""
+        """Async helper to get playlist info via API."""
         try:
             result = await self._get(f"/playlists/{playlist_id}")
 
             if result:
+                items_or_tracks = result.get("items", result.get("tracks", {}))
+                track_count = (
+                    items_or_tracks.get("total", 0)
+                    if isinstance(items_or_tracks, dict)
+                    else 0
+                )
                 return {
                     "success": True,
                     "name": result.get("name", "Unknown Playlist"),
                     "description": result.get("description", ""),
                     "owner": result.get("owner", {}).get("display_name", "Unknown"),
-                    "track_count": result.get("tracks", {}).get("total", 0),
+                    "track_count": track_count,
                     "playlist_id": playlist_id,
                     "public": result.get("public", False),
                     "collaborative": result.get("collaborative", False),
                 }
-            else:
-                return {"success": False, "error": "Failed to fetch playlist from Spotify"}
+            return {
+                "success": False,
+                "error": "Spotify API request failed (check credentials or Premium status for Development Mode)",
+            }
 
         except Exception as e:
             self.logger.error(f"Error fetching playlist info: {e}")
@@ -151,90 +242,83 @@ class SpotifyClient(BaseAPIClient):
 
     async def get_playlist_tracks(self, url: str) -> dict[str, Any]:
         """
-        Get all tracks from a Spotify playlist
-
-        Args:
-            url: Spotify playlist URL
-
-        Returns:
-            Dict with tracks list or error info
+        Get all tracks from a Spotify playlist.
+        Uses API when credentials configured; falls back to scraper when not or on API failure.
         """
         try:
-            # Parse URL to get playlist ID
             parsed = parse_playlist_url(url)
             if not parsed["valid"]:
                 return {"success": False, "error": parsed["error"]}
 
-            playlist_id = parsed["playlist_id"]
+            if not self._has_credentials():
+                scraper_result = await self._get_playlist_via_scraper(url)
+                return scraper_result
 
-            # Fetch tracks from Spotify using the async method
-            return await self._get_playlist_tracks_async(playlist_id)
+            api_result = await self._get_playlist_tracks_async(parsed["playlist_id"])
+            if api_result.get("success"):
+                return api_result
+            self.logger.info("API failed, falling back to scraper")
+            return await self._get_playlist_via_scraper(url)
 
         except Exception as e:
             self.logger.error(f"Error getting playlist tracks: {e}")
             return {"success": False, "error": f"Failed to fetch playlist tracks: {str(e)}"}
 
     async def _get_playlist_tracks_async(self, playlist_id: str) -> dict[str, Any]:
-        """Async helper to get all playlist tracks with pagination"""
+        """Async helper to get all playlist tracks with pagination. Feb 2026: uses /items."""
         try:
             all_tracks = []
             offset = 0
-            limit = 100  # Spotify's max per request
+            limit = 100
 
             while True:
                 params = {
                     "limit": limit,
                     "offset": offset,
-                    "fields": "items(track(name,artists(name),album(name)))",
+                    "fields": "items(item(name,artists(name),album(name)),track(name,artists(name),album(name)))",
                 }
 
-                result = await self._get(f"/playlists/{playlist_id}/tracks", params=params)
+                result = await self._get(f"/playlists/{playlist_id}/items", params=params)
 
                 if not result:
+                    if offset == 0:
+                        return {
+                            "success": False,
+                            "error": "Spotify API request failed (check credentials or Premium status for Development Mode)",
+                            "tracks": [],
+                            "total_tracks": 0,
+                        }
                     break
 
                 tracks = result.get("items", [])
                 if not tracks:
                     break
 
-                # Process tracks
+                from utils.text_normalizer import normalize_text
+
                 for item in tracks:
-                    track = item.get("track", {})
-                    if track and track.get("name"):  # Skip null tracks
+                    track = item.get("item", item.get("track", {}))
+                    if track and track.get("name"):
                         artists = track.get("artists", [])
                         artist_name = (
                             artists[0].get("name", "Unknown Artist")
                             if artists
                             else "Unknown Artist"
                         )
-
-                        # Extract album name before normalization
                         raw_album_name = track.get("album", {}).get("name", "Unknown Album")
-
-                        # Normalize text for consistent matching
-                        from utils.text_normalizer import normalize_text
-
-                        artist_name = normalize_text(artist_name)
-                        track_name = normalize_text(track.get("name", "Unknown Track"))
-                        album_name = normalize_text(raw_album_name)
-
-                        # Debug log album extraction
-                        self.logger.debug(
-                            f"🎵 SPOTIFY EXTRACT: '{track_name}' by '{artist_name}' from album '{album_name}' (raw: '{raw_album_name}')"
-                        )
-
                         all_tracks.append(
-                            {"artist": artist_name, "track": track_name, "album": album_name}
+                            {
+                                "artist": normalize_text(artist_name),
+                                "track": normalize_text(track.get("name", "Unknown Track")),
+                                "album": normalize_text(raw_album_name),
+                            }
                         )
 
-                # Check if we got less than requested (end of results)
                 if len(tracks) < limit:
                     break
 
                 offset += limit
-
-                # Safety check to prevent infinite loops
-                if offset > 10000:  # Spotify playlist limit
+                if offset > 10000:
                     self.logger.warning("Reached safety limit for playlist tracks")
                     break
 
@@ -290,34 +374,49 @@ class SpotifyClient(BaseAPIClient):
     async def search_artists(self, name: str, limit: int = 5) -> dict[str, Any]:
         """
         Search for artists by name on Spotify.
-
-        Args:
-            name: Artist name to search for
-            limit: Maximum number of results (default 5, max 50)
-
-        Returns:
-            Dict with success, artists list (id, name, uri) or error info
+        Feb 2026: search limit max 10 per request; paginate if more needed.
         """
         try:
-            params = {"q": f'artist:"{name}"', "type": "artist", "limit": min(limit, 50)}
-            result = await self._get("/search", params=params)
+            page_limit = min(limit, 10)
+            all_artists = []
+            offset = 0
 
-            if not result:
-                return {"success": False, "error": "No response from Spotify", "artists": []}
+            while len(all_artists) < limit:
+                params = {
+                    "q": f'artist:"{name}"',
+                    "type": "artist",
+                    "limit": page_limit,
+                    "offset": offset,
+                }
+                result = await self._get("/search", params=params)
 
-            artists_data = result.get("artists", {}).get("items", [])
-            artists = []
-            for artist in artists_data:
-                artists.append(
-                    {
-                        "id": artist.get("id"),
-                        "name": artist.get("name"),
-                        "uri": artist.get("uri"),
-                        "external_url": artist.get("external_urls", {}).get("spotify"),
-                    }
-                )
+                if not result:
+                    if offset == 0:
+                        return {
+                            "success": False,
+                            "error": "No response from Spotify",
+                            "artists": [],
+                        }
+                    break
 
-            return {"success": True, "artists": artists}
+                artists_data = result.get("artists", {}).get("items", [])
+                for artist in artists_data:
+                    all_artists.append(
+                        {
+                            "id": artist.get("id"),
+                            "name": artist.get("name"),
+                            "uri": artist.get("uri"),
+                            "external_url": artist.get("external_urls", {}).get("spotify"),
+                        }
+                    )
+
+                if len(artists_data) < page_limit:
+                    break
+                offset += page_limit
+                if offset >= 50:
+                    break
+
+            return {"success": True, "artists": all_artists[:limit]}
 
         except Exception as e:
             self.logger.error(f"Error searching for artist '{name}': {e}")
@@ -401,33 +500,34 @@ class SpotifyClient(BaseAPIClient):
             return {"success": False, "error": str(e), "albums": []}
 
     async def test_connection(self) -> bool:
-        """Test connection to Spotify API"""
+        """Test connection: API when credentials configured, scraper when not."""
         try:
-            self.logger.info("Testing connection to Spotify API...")
-
-            # Try to get access token
-            if not await self._ensure_valid_token():
-                self.logger.error("Failed to obtain Spotify access token")
-                return False
-
-            # Test with a public endpoint that works with Client Credentials
-            # Using a well-known track ID to test API access
-            result = await self._get(
-                "/tracks/4iV5W9uYEdYUVa79Axb7Rh"
-            )  # "Never Gonna Give You Up" by Rick Astley
-
-            if result:
-                self.logger.info("Successfully connected to Spotify API")
-                return True
-            else:
+            if self._has_credentials():
+                self.logger.info("Testing connection to Spotify API...")
+                if not await self._ensure_valid_token():
+                    self.logger.error("Failed to obtain Spotify access token")
+                    return False
+                result = await self._get("/tracks/4iV5W9uYEdYUVa79Axb7Rh")
+                if result:
+                    self.logger.info("Successfully connected to Spotify API")
+                    return True
                 self.logger.error("Spotify API test failed - no valid response")
                 return False
+
+            self.logger.info("Testing Spotify scraper (no credentials)...")
+            scraper_result = await self._get_playlist_via_scraper(
+                "https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M"
+            )
+            if scraper_result.get("success"):
+                self.logger.info("Spotify scraper test passed")
+                return True
+            self.logger.error(f"Spotify scraper test failed: {scraper_result.get('error')}")
+            return False
 
         except Exception as e:
             self.logger.error(f"Failed to connect to Spotify: {e}")
             return False
         finally:
-            # Ensure session is closed
             if self.session:
                 await self.session.close()
                 self.session = None

--- a/clients/client_spotify.py
+++ b/clients/client_spotify.py
@@ -217,9 +217,7 @@ class SpotifyClient(BaseAPIClient):
             if result:
                 items_or_tracks = result.get("items", result.get("tracks", {}))
                 track_count = (
-                    items_or_tracks.get("total", 0)
-                    if isinstance(items_or_tracks, dict)
-                    else 0
+                    items_or_tracks.get("total", 0) if isinstance(items_or_tracks, dict) else 0
                 )
                 return {
                     "success": True,

--- a/commands/daylist.py
+++ b/commands/daylist.py
@@ -298,10 +298,14 @@ class DaylistCommand(BaseCommand):
         candidate_rk: str | int,
         limit: int = 20,
         max_distance: float = 1.0,
+        library_key: str | None = None,
     ) -> int:
         """Score: index in sonically similar list (lower = more similar). 100 if not found."""
         similars = self.plex_client.get_sonically_similar(
-            str(current_rk), limit=limit, max_distance=max_distance
+            str(current_rk),
+            limit=limit,
+            max_distance=max_distance,
+            library_key=library_key,
         )
         for i, s in enumerate(similars):
             if str(s.get("ratingKey")) == str(candidate_rk):
@@ -313,6 +317,7 @@ class DaylistCommand(BaseCommand):
         tracks: list[dict],
         limit: int = 20,
         max_distance: float = 1.0,
+        library_key: str | None = None,
     ) -> list[dict]:
         """Greedy sonic sort: chain tracks by similarity."""
         if len(tracks) < 2:
@@ -327,7 +332,7 @@ class DaylistCommand(BaseCommand):
             next_track = min(
                 remaining,
                 key=lambda c: self._similarity_score(
-                    current_rk, c.get("ratingKey"), limit, max_distance
+                    current_rk, c.get("ratingKey"), limit, max_distance, library_key
                 ),
             )
             sorted_list.append(next_track)
@@ -655,7 +660,10 @@ class DaylistCommand(BaseCommand):
                 if not rk:
                     continue
                 sims = self.plex_client.get_sonically_similar(
-                    str(rk), limit=sonic_limit, max_distance=sonic_similarity_distance
+                    str(rk),
+                    limit=sonic_limit,
+                    max_distance=sonic_similarity_distance,
+                    library_key=library_key,
                 )
                 for s in sims:
                     if str(s.get("ratingKey")) in excluded_keys:
@@ -678,6 +686,7 @@ class DaylistCommand(BaseCommand):
                         str(t.get("ratingKey")),
                         limit=sonic_limit,
                         max_distance=sonic_similarity_distance,
+                        library_key=library_key,
                     )
                     more_sim.extend(sims)
                 candidates = [
@@ -716,7 +725,10 @@ class DaylistCommand(BaseCommand):
 
             if middle:
                 middle = self._sort_by_sonic_similarity(
-                    middle, limit=sonic_similarity_limit, max_distance=sonic_similarity_distance
+                    middle,
+                    limit=sonic_similarity_limit,
+                    max_distance=sonic_similarity_distance,
+                    library_key=library_key,
                 )
             ordered = []
             if first_track:

--- a/commands/daylist.py
+++ b/commands/daylist.py
@@ -571,8 +571,7 @@ class DaylistCommand(BaseCommand):
                 return False
 
             # Resolve library
-            music_libs = self.plex_client.get_music_libraries()
-            chosen = self.plex_client._resolve_music_library(music_libs)
+            chosen = self.plex_client.get_resolved_library()
             if not chosen:
                 self.logger.error("No music library found")
                 return False

--- a/commands/library_cache_builder.py
+++ b/commands/library_cache_builder.py
@@ -11,7 +11,9 @@ from typing import Any
 
 from clients.client_jellyfin import JellyfinClient
 from clients.client_plex import PlexClient
+from services.config_service import config_service
 from utils.library_cache_manager import get_library_cache_manager
+from utils.library_selector import resolve_plex_library
 
 from .command_base import BaseCommand
 
@@ -264,7 +266,16 @@ class LibraryCacheBuilderCommand(BaseCommand):
             if force_rebuild or not existing_cache:
                 # Full rebuild - use existing method
                 self.logger.info(f"Performing full cache rebuild for {target}")
-                return client.build_library_cache()
+                cache_data = client.build_library_cache()
+                if cache_data and target == "plex":
+                    lib_key = cache_data.get("library_key")
+                    if lib_key:
+                        config_service.set("PLEX_LIBRARY_KEY", str(lib_key))
+                elif cache_data and target == "jellyfin":
+                    lib_key = cache_data.get("library_key")
+                    if lib_key:
+                        config_service.set("JELLYFIN_LIBRARY_KEY", str(lib_key))
+                return cache_data
 
             # Smart incremental rebuild
             self.logger.info(
@@ -288,8 +299,9 @@ class LibraryCacheBuilderCommand(BaseCommand):
 
             if target == "plex":
                 # Use resolved library (same as full build - respects PLEX_LIBRARY_NAME)
-                music_libraries = client.get_music_libraries()
-                chosen = client._resolve_music_library(music_libraries)
+                chosen = resolve_plex_library(client)
+                if chosen:
+                    config_service.set("PLEX_LIBRARY_KEY", str(chosen.get("key", "")))
                 libraries = [chosen] if chosen else []
 
                 for library in libraries:

--- a/commands/playlist_generator_local_discovery.py
+++ b/commands/playlist_generator_local_discovery.py
@@ -80,15 +80,19 @@ class PlaylistGeneratorLocalDiscoveryCommand(BaseCommand):
                 self.logger.error("plex_history_account_id is required")
                 return False
 
-            # Prefer resolved library (PLEX_LIBRARY_NAME / Music / first) over stored target_library_key
+            # Always use resolved library (PLEX_LIBRARY_NAME / Music / first) - never use stored
+            # target_library_key, which may point to wrong library (e.g. Audiobooks when Music desired)
             library_key = None
-            if hasattr(self.plex_client, "get_resolved_library_key"):
-                library_key = self.plex_client.get_resolved_library_key()
+            resolved_lib = None
+            if hasattr(self.plex_client, "get_resolved_library"):
+                resolved_lib = self.plex_client.get_resolved_library()
+                library_key = resolved_lib["key"] if resolved_lib else None
             if not library_key:
-                library_key = config.get("target_library_key")
-            if not library_key:
-                self.logger.error("No target library configured")
+                self.logger.error(
+                    "No Plex music library found. Configure PLEX_LIBRARY_NAME or ensure a music library exists."
+                )
                 return False
+            self.logger.info(f"Using library: {resolved_lib.get('title', '?')} (key={library_key})")
 
             lookback_days = int(config.get("lookback_days", 90))
             exclude_played_days = int(config.get("exclude_played_days", 3))

--- a/commands/playlist_generator_local_discovery.py
+++ b/commands/playlist_generator_local_discovery.py
@@ -80,9 +80,12 @@ class PlaylistGeneratorLocalDiscoveryCommand(BaseCommand):
                 self.logger.error("plex_history_account_id is required")
                 return False
 
-            library_key = config.get("target_library_key")
-            if not library_key and hasattr(self.plex_client, "get_resolved_library_key"):
+            # Prefer resolved library (PLEX_LIBRARY_NAME / Music / first) over stored target_library_key
+            library_key = None
+            if hasattr(self.plex_client, "get_resolved_library_key"):
                 library_key = self.plex_client.get_resolved_library_key()
+            if not library_key:
+                library_key = config.get("target_library_key")
             if not library_key:
                 self.logger.error("No target library configured")
                 return False
@@ -178,7 +181,10 @@ class PlaylistGeneratorLocalDiscoveryCommand(BaseCommand):
                 if not rk:
                     continue
                 sims = self.plex_client.get_sonically_similar(
-                    str(rk), limit=sonic_limit, max_distance=sonic_distance
+                    str(rk),
+                    limit=sonic_limit,
+                    max_distance=sonic_distance,
+                    library_key=library_key,
                 )
                 for s in sims:
                     sk = str(s.get("ratingKey", ""))

--- a/commands/playlist_generator_mood.py
+++ b/commands/playlist_generator_mood.py
@@ -140,14 +140,15 @@ class PlaylistGeneratorMoodCommand(BaseCommand):
             max_tracks = max(1, min(200, max_tracks))
             exclude_last_run = config.get("exclude_last_run", True)
 
-            # Prefer resolved library (PLEX_LIBRARY_NAME / Music / first) over stored target_library_key
+            # Always use resolved library (PLEX_LIBRARY_NAME / Music / first) - never stored
+            # target_library_key, which may point to wrong library
             library_key = None
             if hasattr(self.plex_client, "get_resolved_library_key"):
                 library_key = self.plex_client.get_resolved_library_key()
             if not library_key:
-                library_key = config.get("target_library_key")
-            if not library_key:
-                self.logger.error("No target library configured")
+                self.logger.error(
+                    "No Plex music library found. Configure PLEX_LIBRARY_NAME or ensure a music library exists."
+                )
                 return False
 
             # 1. Fetch tracks per mood, union and count mood matches per track

--- a/commands/playlist_generator_mood.py
+++ b/commands/playlist_generator_mood.py
@@ -140,9 +140,12 @@ class PlaylistGeneratorMoodCommand(BaseCommand):
             max_tracks = max(1, min(200, max_tracks))
             exclude_last_run = config.get("exclude_last_run", True)
 
-            library_key = config.get("target_library_key")
-            if not library_key and hasattr(self.plex_client, "get_resolved_library_key"):
+            # Prefer resolved library (PLEX_LIBRARY_NAME / Music / first) over stored target_library_key
+            library_key = None
+            if hasattr(self.plex_client, "get_resolved_library_key"):
                 library_key = self.plex_client.get_resolved_library_key()
+            if not library_key:
+                library_key = config.get("target_library_key")
             if not library_key:
                 self.logger.error("No target library configured")
                 return False

--- a/commands/playlist_generator_top_tracks.py
+++ b/commands/playlist_generator_top_tracks.py
@@ -155,11 +155,12 @@ class PlaylistGeneratorTopTracksCommand(BaseCommand):
             top_x = max(1, min(20, top_x))
             source = str(config.get("source", "plex")).lower()
             target_client, target_name = self._get_target_client()
-            library_key = config.get("target_library_key")
-
-            if not library_key and hasattr(target_client, "get_resolved_library_key"):
+            # Prefer resolved library (PLEX/JELLYFIN_LIBRARY_NAME / Music / first) over stored target_library_key
+            library_key = None
+            if hasattr(target_client, "get_resolved_library_key"):
                 library_key = target_client.get_resolved_library_key()
-
+            if not library_key:
+                library_key = config.get("target_library_key")
             if not library_key:
                 self.logger.error("No target library configured")
                 return False

--- a/commands/playlist_generator_top_tracks.py
+++ b/commands/playlist_generator_top_tracks.py
@@ -155,14 +155,16 @@ class PlaylistGeneratorTopTracksCommand(BaseCommand):
             top_x = max(1, min(20, top_x))
             source = str(config.get("source", "plex")).lower()
             target_client, target_name = self._get_target_client()
-            # Prefer resolved library (PLEX/JELLYFIN_LIBRARY_NAME / Music / first) over stored target_library_key
+            # Always use resolved library (PLEX/JELLYFIN_LIBRARY_NAME / Music / first) - never stored
+            # target_library_key, which may point to wrong library
             library_key = None
             if hasattr(target_client, "get_resolved_library_key"):
                 library_key = target_client.get_resolved_library_key()
             if not library_key:
-                library_key = config.get("target_library_key")
-            if not library_key:
-                self.logger.error("No target library configured")
+                self.logger.error(
+                    "No target library found. Configure PLEX_LIBRARY_NAME or JELLYFIN_LIBRARY_NAME, "
+                    "or ensure a music library exists."
+                )
                 return False
 
             # Jellyfin target: source must be Last.fm

--- a/commands/playlist_sync.py
+++ b/commands/playlist_sync.py
@@ -117,6 +117,7 @@ class PlaylistSyncCommand(BaseCommand):
             if not tracks_result.get("success"):
                 error_msg = tracks_result.get("error", "Unknown error")
                 self.logger.error(f"Failed to fetch tracks: {error_msg}")
+                self.last_run_stats = {"success": False, "error": error_msg}
                 return False
 
             tracks = tracks_result.get("tracks", [])

--- a/commands/playlist_sync.py
+++ b/commands/playlist_sync.py
@@ -174,41 +174,27 @@ class PlaylistSyncCommand(BaseCommand):
             if success:
                 self.logger.info(f"Successfully synced playlist '{playlist_title}'")
 
-                # Artist discovery (if enabled)
-                artist_discovery_stats = None
-                self.logger.info("Checking if artist discovery is enabled...")
-                if config.get("enable_artist_discovery", False):
-                    self.logger.info("Artist discovery is enabled, proceeding...")
-                    # Extract unmatched tracks from sync result
-                    unmatched_tracks = sync_stats.get("unmatched_tracks", [])
-                    self.logger.info(f"Sync stats: {sync_stats}")
-                    self.logger.info(f"Unmatched tracks from sync: {unmatched_tracks}")
-                    if unmatched_tracks:
-                        self.logger.info(
-                            f"Found {len(unmatched_tracks)} unmatched tracks for artist discovery"
-                        )
-                        # Convert unmatched track strings back to track objects for artist discovery
-                        unmatched_track_objects = []
-                        for track_string in unmatched_tracks:
-                            if " - " in track_string:
-                                artist, track_name = track_string.split(" - ", 1)
-                                unmatched_track_objects.append(
-                                    {"artist": artist.strip(), "track": track_name.strip()}
-                                )
-                        artist_discovery_stats = await self._discover_and_add_artists(
-                            unmatched_track_objects, cached_data
-                        )
-                    else:
-                        self.logger.info("No unmatched tracks found - skipping artist discovery")
-                        artist_discovery_stats = {
-                            "total_artists": 0,
-                            "artists_added": 0,
-                            "artists_skipped": 0,
-                            "artists_failed": 0,
-                            "added_artists": [],
-                            "skipped_artists": [],
-                            "failed_artists": [],
-                        }
+                # Artist discovery: always run to count new artists; conditionally add to import list
+                unmatched_tracks = sync_stats.get("unmatched_tracks", [])
+                if unmatched_tracks:
+                    unmatched_track_objects = []
+                    for track_string in unmatched_tracks:
+                        if " - " in track_string:
+                            artist, track_name = track_string.split(" - ", 1)
+                            unmatched_track_objects.append(
+                                {"artist": artist.strip(), "track": track_name.strip()}
+                            )
+                    artist_discovery_stats = await self._discover_and_add_artists(
+                        unmatched_track_objects, cached_data
+                    )
+                else:
+                    artist_discovery_stats = {
+                        "artists_discovered": 0,
+                        "artists_added": 0,
+                        "artists_skipped": 0,
+                        "artists_failed": 0,
+                        "artists_deferred": 0,
+                    }
 
                 # Get sync statistics from target client
                 # sync_stats already contains the result from sync operation
@@ -261,10 +247,12 @@ class PlaylistSyncCommand(BaseCommand):
             if not unique_artists:
                 self.logger.info("No artists found in tracks for discovery")
                 return {
+                    "artists_discovered": 0,
                     "total_artists": 0,
                     "artists_added": 0,
                     "artists_skipped": 0,
                     "artists_failed": 0,
+                    "artists_deferred": 0,
                     "added_artists": [],
                     "skipped_artists": [],
                     "failed_artists": [],
@@ -287,10 +275,12 @@ class PlaylistSyncCommand(BaseCommand):
                     "MusicBrainz is disabled - cannot discover artists without MBID lookup"
                 )
                 return {
+                    "artists_discovered": 0,
                     "total_artists": len(unique_artists),
                     "artists_added": 0,
                     "artists_skipped": len(unique_artists),
                     "artists_failed": 0,
+                    "artists_deferred": 0,
                     "added_artists": [],
                     "skipped_artists": list(unique_artists),
                     "failed_artists": [],
@@ -375,22 +365,48 @@ class PlaylistSyncCommand(BaseCommand):
                         self.logger.warning(f"Error processing artist {artist_name}: {e}")
                         continue
 
-                # Save discovered artists to import list
-                if new_discoveries:
-                    await self._save_discovered_artists(new_discoveries)
+                artists_discovered = len(new_discoveries)
+                to_save = []
+                artists_deferred = 0
+                is_first_run = self.config_json.get("is_first_run", False)
+                enable_artist_discovery = self.config_json.get("enable_artist_discovery", False)
+
+                if new_discoveries and not is_first_run and enable_artist_discovery:
+                    limit = self.config_json.get("artist_discovery_max_per_run", 2)
+                    if limit == 0:
+                        to_save = new_discoveries
+                    else:
+                        to_save = new_discoveries[:limit]
+                        artists_deferred = len(new_discoveries) - len(to_save)
+                        if artists_deferred > 0:
+                            self.logger.info(
+                                f"Limiting to {limit} new artists per run; {artists_deferred} deferred to next run"
+                            )
+
+                if to_save:
+                    await self._save_discovered_artists(to_save)
 
                 # Log summary
-                self.logger.info(
-                    f"Artist discovery completed: {artists_added} added to import list, {artists_skipped} skipped, {artists_failed} failed"
-                )
+                if is_first_run:
+                    self.logger.info(
+                        f"Artist discovery (first run): {artists_discovered} detected, none added"
+                    )
+                else:
+                    self.logger.info(
+                        f"Artist discovery completed: {len(to_save)} added to import list, "
+                        f"{artists_skipped} skipped, {artists_failed} failed"
+                    )
 
                 # Return detailed statistics
                 return {
+                    "artists_discovered": artists_discovered,
                     "total_artists": len(unique_artists),
-                    "artists_added": artists_added,
+                    "artists_added": len(to_save),
                     "artists_skipped": artists_skipped,
                     "artists_failed": artists_failed,
-                    "added_artists": added_artists,
+                    "artists_deferred": artists_deferred,
+                    "first_run_preview": is_first_run and artists_discovered > 0,
+                    "added_artists": added_artists[: len(to_save)] if to_save else [],
                     "skipped_artists": skipped_artists,
                     "failed_artists": failed_artists,
                 }
@@ -401,10 +417,12 @@ class PlaylistSyncCommand(BaseCommand):
         except Exception as e:
             self.logger.error(f"Error during artist discovery: {e}")
             return {
+                "artists_discovered": 0,
                 "total_artists": len(unique_artists) if "unique_artists" in locals() else 0,
                 "artists_added": 0,
                 "artists_skipped": 0,
                 "artists_failed": 0,
+                "artists_deferred": 0,
                 "added_artists": [],
                 "skipped_artists": [],
                 "failed_artists": [],

--- a/commands/playlist_sync_listenbrainz.py
+++ b/commands/playlist_sync_listenbrainz.py
@@ -143,12 +143,10 @@ class PlaylistSyncListenBrainzCommand(PlaylistSyncCommand):
             if success:
                 await self._cleanup_old_playlists()
 
-            # Universal artist discovery (if enabled)
-            if self.config_json.get("enable_artist_discovery", False):
-                self.logger.info("Artist discovery is enabled, proceeding with discovery...")
-                await self._discover_missing_artists(sync_results)
-            else:
-                self.logger.info("Artist discovery is disabled, skipping discovery...")
+            # Artist discovery: always run to count new artists; conditionally add to import list
+            artist_discovery_stats = await self._discover_missing_artists(sync_results)
+            if artist_discovery_stats is not None:
+                self.last_run_stats["artist_discovery"] = artist_discovery_stats
 
             # Determine overall success
             if success:
@@ -1112,7 +1110,12 @@ class PlaylistSyncListenBrainzCommand(PlaylistSyncCommand):
 
             if not unmatched_artists:
                 self.logger.info("No unmatched artists found for discovery")
-                return
+                return {
+                    "artists_discovered": 0,
+                    "artists_added": 0,
+                    "artists_failed": 0,
+                    "artists_deferred": 0,
+                }
 
             # Use existing discovery utilities for MBID lookup and filtering
             from clients.client_lidarr import LidarrClient
@@ -1128,7 +1131,12 @@ class PlaylistSyncListenBrainzCommand(PlaylistSyncCommand):
                 self.logger.error(
                     "MusicBrainz is disabled - cannot discover artists without MBID lookup"
                 )
-                return
+                return {
+                    "artists_discovered": 0,
+                    "artists_added": 0,
+                    "artists_failed": 0,
+                    "artists_deferred": 0,
+                }
 
             try:
                 discovery_utils = DiscoveryUtils(self.config, lidarr_client, musicbrainz_client)
@@ -1158,26 +1166,54 @@ class PlaylistSyncListenBrainzCommand(PlaylistSyncCommand):
                     f"listenbrainz_playlist_sync_{self.config_json.get('unique_id', 'unknown')}",
                 )
 
+                artists_discovered = len(discovered_artists) if discovered_artists else 0
                 self.logger.info(
-                    f"MusicBrainz processing returned {len(discovered_artists) if discovered_artists else 0} discovered artists"
+                    f"MusicBrainz processing returned {artists_discovered} discovered artists"
                 )
 
-                if discovered_artists:
-                    # Save to unified discovery file
-                    await self._save_discovered_artists(discovered_artists)
+                is_first_run = self.config_json.get("is_first_run", False)
+                enable_artist_discovery = self.config_json.get("enable_artist_discovery", False)
+                to_save = []
+                artists_deferred = 0
+
+                if discovered_artists and not is_first_run and enable_artist_discovery:
+                    limit = self.config_json.get("artist_discovery_max_per_run", 2)
+                    if limit == 0:
+                        to_save = discovered_artists
+                    else:
+                        to_save = discovered_artists[:limit]
+                        artists_deferred = len(discovered_artists) - len(to_save)
+                        if artists_deferred > 0:
+                            self.logger.info(
+                                f"Limiting to {limit} new artists per run; {artists_deferred} deferred to next run"
+                            )
+
+                if to_save:
+                    await self._save_discovered_artists(to_save)
+                    self.logger.info(f"Saved {len(to_save)} new artists to Lidarr import list")
+                elif is_first_run and artists_discovered > 0:
                     self.logger.info(
-                        f"Discovered {len(discovered_artists)} new artists for Lidarr import"
+                        f"Artist discovery (first run): {artists_discovered} detected, none added"
                     )
-                else:
-                    self.logger.info(
-                        "No new artists discovered (all were already in Lidarr or excluded)"
-                    )
+                return {
+                    "artists_discovered": artists_discovered,
+                    "artists_added": len(to_save),
+                    "artists_failed": 0,
+                    "artists_deferred": artists_deferred,
+                    "first_run_preview": is_first_run and artists_discovered > 0,
+                }
             finally:
                 if musicbrainz_client and hasattr(musicbrainz_client, "close"):
                     await musicbrainz_client.close()
 
         except Exception as e:
             self.logger.error(f"Error during artist discovery: {e}", exc_info=True)
+            return {
+                "artists_discovered": 0,
+                "artists_added": 0,
+                "artists_failed": 0,
+                "artists_deferred": 0,
+            }
 
     async def _save_discovered_artists(self, discovered_artists: list[dict[str, Any]]):
         """Save discovered artists to playlist sync discovery file"""

--- a/frontend/src/components/CreatePlaylistSyncDialog.tsx
+++ b/frontend/src/components/CreatePlaylistSyncDialog.tsx
@@ -97,6 +97,7 @@ export function CreatePlaylistSyncDialog({
     daily_jams_keep: 3,
     cleanup_enabled: true,
     enable_artist_discovery: false,
+    artist_discovery_max_per_run: 2,
     schedule_cron: "0 6 * * *",
     schedule_override: false,
     expires_at_enabled: false,
@@ -1984,13 +1985,45 @@ export function CreatePlaylistSyncDialog({
                         htmlFor="create-enable-artist-discovery"
                         className="cursor-pointer font-normal"
                       >
-                        Enable artist discovery
+                        Add new artists
                       </Label>
                     </div>
                     <p className="text-xs text-muted-foreground">
-                      When tracks fail to match in your library, discover and add artists from those
-                      tracks.
+                      Artists discovered missing from Lidarr are added to the Playlist Sync
+                      Discovery import list. Discovery always runs to report counts; this controls
+                      whether to add.
                     </p>
+                    {formData.enable_artist_discovery && (
+                      <div className="space-y-2 rounded-lg border p-4">
+                        <Label htmlFor="create-artist-discovery-max">
+                          Max artists to add per run
+                        </Label>
+                        <Input
+                          id="create-artist-discovery-max"
+                          type="text"
+                          inputMode="numeric"
+                          placeholder="2"
+                          value={
+                            formData.artist_discovery_max_per_run ??
+                            (formData.enable_artist_discovery ? 2 : 0)
+                          }
+                          onChange={(e) => {
+                            const v = parseInt(e.target.value, 10);
+                            setFormData((prev) => ({
+                              ...prev,
+                              artist_discovery_max_per_run: isNaN(v)
+                                ? (prev.artist_discovery_max_per_run ?? 2)
+                                : v,
+                            }));
+                          }}
+                        />
+                        <p className="text-xs text-muted-foreground">
+                          0 = no limit. Limits how many new artists are added per sync run;
+                          remaining artists are added on subsequent runs. First run adds none—only
+                          reports count.
+                        </p>
+                      </div>
+                    )}
                   </div>
 
                   <ExpirationFields

--- a/frontend/src/components/CreatePlaylistSyncDialog.tsx
+++ b/frontend/src/components/CreatePlaylistSyncDialog.tsx
@@ -222,6 +222,7 @@ export function CreatePlaylistSyncDialog({
         daily_jams_keep: 3,
         cleanup_enabled: true,
         enable_artist_discovery: false,
+        artist_discovery_max_per_run: 2,
         schedule_cron: "0 6 * * *",
         schedule_override: false,
         expires_at_enabled: false,

--- a/frontend/src/pages/Commands.tsx
+++ b/frontend/src/pages/Commands.tsx
@@ -180,11 +180,40 @@ export function CommandsPage() {
   const [recentExecutions, setRecentExecutions] = useState<CommandExecution[]>([]);
   const [expandedExecutionId, setExpandedExecutionId] = useState<number | null>(null);
   const [killingExecutionId, setKillingExecutionId] = useState<number | null>(null);
+  const [nrdSources, setNrdSources] = useState<
+    { id: string; name: string; configured: boolean }[]
+  >([]);
 
   useEffect(() => {
     loadCommands();
     loadExecutions();
   }, []);
+
+  useEffect(() => {
+    if (editingCommand?.command_name === "new_releases_discovery") {
+      api
+        .request<{ sources: { id: string; name: string; configured: boolean }[] }>(
+          "/api/commands/new-releases-sources"
+        )
+        .then((r) => setNrdSources(r.sources || []))
+        .catch(() => setNrdSources([]));
+    } else {
+      setNrdSources([]);
+    }
+  }, [editingCommand?.command_name]);
+
+  useEffect(() => {
+    if (
+      editingCommand?.command_name === "new_releases_discovery" &&
+      nrdSources.length > 0 &&
+      editForm.new_releases_source === "spotify"
+    ) {
+      const spotifySrc = nrdSources.find((s) => s.id === "spotify");
+      if (spotifySrc && !spotifySrc.configured) {
+        setEditForm((f) => ({ ...f, new_releases_source: "deezer" }));
+      }
+    }
+  }, [editingCommand?.command_name, nrdSources, editForm.new_releases_source]);
 
   useEffect(() => {
     try {
@@ -2294,7 +2323,18 @@ export function CommandsPage() {
                             <option value="deezer">
                               Deezer (no account configuration required)
                             </option>
-                            <option value="spotify">Spotify (set credentials in Config)</option>
+                            <option
+                              value="spotify"
+                              disabled={
+                                !!nrdSources.find((s) => s.id === "spotify" && !s.configured)
+                              }
+                            >
+                              Spotify (
+                              {nrdSources.find((s) => s.id === "spotify")?.configured
+                                ? "credentials configured"
+                                : "set credentials in Config"}
+                              )
+                            </option>
                           </select>
                           <p className="text-xs text-muted-foreground">
                             Deezer uses public data; Spotify requires credentials in Config → Music

--- a/frontend/src/pages/Commands.tsx
+++ b/frontend/src/pages/Commands.tsx
@@ -139,6 +139,7 @@ export function CommandsPage() {
     limit?: number;
     min_match_score?: number;
     enable_artist_discovery?: boolean;
+    artist_discovery_max_per_run?: number;
     schedule_minute?: number;
     plex_history_account_id?: string;
     exclude_played_days?: number;
@@ -350,6 +351,8 @@ export function CommandsPage() {
       limit: typeof cfg.limit === "number" ? cfg.limit : 5,
       min_match_score: typeof cfg.min_match_score === "number" ? cfg.min_match_score : 0.9,
       enable_artist_discovery: !!cfg.enable_artist_discovery,
+      artist_discovery_max_per_run:
+        typeof cfg.artist_discovery_max_per_run === "number" ? cfg.artist_discovery_max_per_run : 2,
       schedule_minute: typeof cfg.schedule_minute === "number" ? cfg.schedule_minute : 0,
       plex_history_account_id: (cfg.plex_history_account_id ?? "") as string,
       exclude_played_days:
@@ -1161,13 +1164,40 @@ export function CommandsPage() {
                             htmlFor="edit-enable-artist-discovery"
                             className="cursor-pointer font-normal"
                           >
-                            Enable artist discovery
+                            Add new artists
                           </Label>
                         </div>
                         <p className="text-xs text-muted-foreground">
-                          When tracks fail to match in your library, discover and add artists from
-                          those tracks.
+                          Artists discovered missing from Lidarr are added to the Playlist Sync
+                          Discovery import list. Discovery always runs to report counts; this
+                          controls whether to add.
                         </p>
+                        {editForm.enable_artist_discovery && (
+                          <div className="space-y-2 rounded-lg border p-4">
+                            <Label htmlFor="edit-artist-discovery-max">
+                              Max artists to add per run
+                            </Label>
+                            <Input
+                              id="edit-artist-discovery-max"
+                              type="text"
+                              inputMode="numeric"
+                              placeholder="2"
+                              value={editForm.artist_discovery_max_per_run ?? 2}
+                              onChange={(e) => {
+                                const v = parseInt(e.target.value, 10);
+                                setEditForm((f) => ({
+                                  ...f,
+                                  artist_discovery_max_per_run: isNaN(v)
+                                    ? (f.artist_discovery_max_per_run ?? 2)
+                                    : v,
+                                }));
+                              }}
+                            />
+                            <p className="text-xs text-muted-foreground">
+                              0 = no limit. First run adds none—only reports count.
+                            </p>
+                          </div>
+                        )}
                       </div>
                     )}
 
@@ -2380,6 +2410,9 @@ export function CommandsPage() {
                       const cfg: Record<string, unknown> = {
                         ...(editingCommand.config_json || {}),
                         enable_artist_discovery: editForm.enable_artist_discovery ?? false,
+                        artist_discovery_max_per_run:
+                          editForm.artist_discovery_max_per_run ??
+                          (editForm.enable_artist_discovery ? 2 : 0),
                       };
                       if ((editingCommand.config_json?.source as string) === "listenbrainz") {
                         cfg.weekly_exploration_keep = editForm.weekly_exploration_keep ?? 2;

--- a/frontend/src/pages/Commands.tsx
+++ b/frontend/src/pages/Commands.tsx
@@ -180,9 +180,9 @@ export function CommandsPage() {
   const [recentExecutions, setRecentExecutions] = useState<CommandExecution[]>([]);
   const [expandedExecutionId, setExpandedExecutionId] = useState<number | null>(null);
   const [killingExecutionId, setKillingExecutionId] = useState<number | null>(null);
-  const [nrdSources, setNrdSources] = useState<
-    { id: string; name: string; configured: boolean }[]
-  >([]);
+  const [nrdSources, setNrdSources] = useState<{ id: string; name: string; configured: boolean }[]>(
+    []
+  );
 
   useEffect(() => {
     loadCommands();

--- a/frontend/src/pages/ImportLists.tsx
+++ b/frontend/src/pages/ImportLists.tsx
@@ -236,8 +236,8 @@ export function ImportListsPage() {
             </div>
             <p className="text-muted-foreground mb-4">
               Artists discovered from playlist sync operations (Spotify, ListenBrainz, etc.) when
-              tracks fail to match in your library. Requires &quot;Enable artist discovery&quot; to
-              be checked in the playlist sync command settings (Commands → Edit).
+              tracks fail to match in your library. Requires &quot;Add new artists&quot; to be
+              checked in the playlist sync command settings (Commands → Edit).
             </p>
             <div className="mb-4">
               <label className="block text-sm font-medium mb-1">Endpoint URL</label>

--- a/frontend/src/pages/Status.tsx
+++ b/frontend/src/pages/Status.tsx
@@ -205,10 +205,7 @@ export function StatusPage() {
               <p className="text-xs text-muted-foreground">
                 {status.version}
                 {status.runtime_mode && (
-                  <> · {status.runtime_mode === "docker" ? "Docker" : "Standalone"}</>
-                )}
-                {status.runtime_mode === "docker" && status.docker_image_tag && (
-                  <> · :{status.docker_image_tag}</>
+                  <> · {status.runtime_mode === "docker" ? "Docker" : "Python"}</>
                 )}
               </p>
             </CardContent>

--- a/readme-extended.md
+++ b/readme-extended.md
@@ -155,7 +155,7 @@ Create via Commands → New. All use `[Cmdarr]` prefix; display name syncs with 
 **What it does**: Create unlimited playlist sync commands through the web interface  
 **Benefits**:
 - **ListenBrainz Curated Playlists**: Sync Weekly Exploration, Weekly Jams, Daily Jams
-- **External Playlist Support**: Sync playlists from Spotify, Deezer, and other sources
+- **External Playlist Support**: Sync **public** playlists from Spotify, Deezer, and other sources
 - **Multi-Target Support**: Sync to Plex, Jellyfin, or both simultaneously
 - **Library Cache Optimization**: 3+ minutes → 30 seconds sync time
 - **Smart Playlist Management**: Automatic cleanup, retention policies, and duplicate prevention
@@ -204,7 +204,7 @@ With Library Cache:    1 library fetch + instant memory searches = ~30 seconds
 - **Plex Token**: Get from [Plex Support Guide](https://support.plex.tv/articles/204059436/) (for playlist sync)
 - **Jellyfin Token**: Get from [Jellyfin API Documentation](https://jellyfin.org/docs/general/administration/access-tokens/) (for playlist sync)
 - **Jellyfin User ID**: Found in Jellyfin Dashboard → Users → Select User → User ID
-- **Spotify Client ID & Secret**: Get from [Spotify Developer Dashboard](https://developer.spotify.com/dashboard) (for playlist sync)
+- **Spotify Client ID & Secret**: Get from [Spotify Developer Dashboard](https://developer.spotify.com/dashboard) (for playlist sync, public playlists only)
 
 ### Lidarr Integration
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,5 @@
 # requirements-dev.txt
 -r requirements.txt
 ruff>=0.8.0
+pytest>=7.4.0
+pytest-asyncio>=0.21.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,9 @@ Pillow>=10.0.0
 # IANA timezone database (required for zoneinfo on minimal Linux/Docker; optional on macOS/Windows)
 tzdata>=2024.1
 
+# Spotify playlist scraping (no credentials required for public playlists)
+spotifyscraper>=2.1.0
+
 # For enhanced logging and formatting
 # colorlog>=6.7.0
 

--- a/services/command_executor.py
+++ b/services/command_executor.py
@@ -313,6 +313,13 @@ class CommandExecutor:
                 command.config_json["command_name"] = command_name
                 if config_override:
                     command.config_json.update(config_override)
+                # Pass is_first_run for playlist sync (used for artist discovery: skip add on first run)
+                if (
+                    command_config
+                    and command_name.startswith("playlist_sync_")
+                    and command_name != "playlist_sync_discovery_maintenance"
+                ):
+                    command.config_json["is_first_run"] = command_config.last_run is None
                 self.logger.info(
                     f"Set config_json for {command_name}: {list(command.config_json.keys())}"
                 )
@@ -533,13 +540,25 @@ class CommandExecutor:
             if total_playlists > 0:
                 parts.append(f"{playlists}/{total_playlists} playlists synced in {sync_time:.1f}s")
 
-        # Artist discovery
+        # Artist discovery (always show artists_discovered when present)
         artist_disc = stats.get("artist_discovery", {})
         if artist_disc:
+            discovered = artist_disc.get("artists_discovered", 0)
             added = artist_disc.get("artists_added", 0)
             failed_count = artist_disc.get("artists_failed", 0)
+            deferred = artist_disc.get("artists_deferred", 0)
+            first_run = artist_disc.get("first_run_preview", False)
+            if discovered is not None and discovered >= 0:
+                if first_run:
+                    parts.append(
+                        f"{discovered} new artists detected (first run—none added; will add on next run)"
+                    )
+                else:
+                    parts.append(f"{discovered} new artists detected")
             if added > 0:
                 parts.append(f"{added} artists added to Lidarr")
+            if deferred > 0:
+                parts.append(f"{deferred} deferred to next run")
             if failed_count > 0:
                 parts.append(f"{failed_count} artists failed")
 

--- a/services/command_executor.py
+++ b/services/command_executor.py
@@ -342,9 +342,18 @@ class CommandExecutor:
                 command_name, success, duration, command=cmd_obj
             )
 
-            # Update execution record
+            error_message = None
+            if not success and cmd_obj:
+                stats = getattr(cmd_obj, "last_run_stats", None)
+                if stats:
+                    error_message = stats.get("error") or stats.get("message")
+
             await self._update_execution_record(
-                execution_id, success=success, duration=duration, output_summary=output_summary
+                execution_id,
+                success=success,
+                duration=duration,
+                output_summary=output_summary,
+                error_message=error_message,
             )
 
             self.logger.info(
@@ -416,10 +425,12 @@ class CommandExecutor:
         self, command_name: str, success: bool, duration: float, command: Any = None
     ) -> str:
         """Generate a summary from command result (no log parsing)"""
-        if not success:
-            return f"Command failed after {duration:.1f}s"
-
         stats = getattr(command, "last_run_stats", None) if command else None
+        if not success:
+            err = (stats or {}).get("error") or (stats or {}).get("message")
+            if err:
+                return f"Command failed after {duration:.1f}s: {err}"
+            return f"Command failed after {duration:.1f}s"
 
         if command_name == "discovery_lastfm" and stats:
             return self._build_lastfm_summary(stats, duration)

--- a/services/config_service.py
+++ b/services/config_service.py
@@ -294,7 +294,7 @@ class ConfigService:
                 "default_value": "",
                 "data_type": "string",
                 "category": "spotify",
-                "description": "Spotify API Client ID",
+                "description": "Spotify API Client ID (public playlists, New Releases)",
                 "is_sensitive": True,
             },
             {
@@ -302,7 +302,7 @@ class ConfigService:
                 "default_value": "",
                 "data_type": "string",
                 "category": "spotify",
-                "description": "Spotify API Client Secret",
+                "description": "Spotify API Client Secret (public playlists, New Releases)",
                 "is_sensitive": True,
             },
             {

--- a/services/config_service.py
+++ b/services/config_service.py
@@ -221,6 +221,14 @@ class ConfigService:
                 "category": "plex",
                 "description": "Plex music library name to use (e.g. Music). Empty = auto-select (prefers Music over Audiobooks)",
             },
+            {
+                "key": "PLEX_LIBRARY_KEY",
+                "default_value": "",
+                "data_type": "string",
+                "category": "plex",
+                "description": "Resolved Plex library key (auto-managed, do not set manually)",
+                "is_hidden": True,
+            },
             # Jellyfin Configuration
             {
                 "key": "JELLYFIN_CLIENT_ENABLED",
@@ -271,6 +279,14 @@ class ConfigService:
                 "data_type": "string",
                 "category": "jellyfin",
                 "description": "Jellyfin music library name to use. Empty = use default",
+            },
+            {
+                "key": "JELLYFIN_LIBRARY_KEY",
+                "default_value": "",
+                "data_type": "string",
+                "category": "jellyfin",
+                "description": "Resolved Jellyfin library key (auto-managed, do not set manually)",
+                "is_hidden": True,
             },
             # Spotify Configuration
             {

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Unit tests package

--- a/tests/test_playlist_parser.py
+++ b/tests/test_playlist_parser.py
@@ -1,0 +1,32 @@
+"""Unit tests for playlist URL parser"""
+import pytest
+from utils.playlist_parser import parse_playlist_url
+
+
+def test_parse_spotify_url_valid():
+    result = parse_playlist_url(
+        "https://open.spotify.com/playlist/4NDXWHwYWjFmgVPkNy4YlF"
+    )
+    assert result["valid"] is True
+    assert result["source"] == "spotify"
+    assert result["playlist_id"] == "4NDXWHwYWjFmgVPkNy4YlF"
+
+
+def test_parse_spotify_url_with_query():
+    result = parse_playlist_url("https://open.spotify.com/playlist/abc123?si=xyz")
+    assert result["valid"] is True
+    assert result["source"] == "spotify"
+    assert result["playlist_id"] == "abc123"
+
+
+def test_parse_deezer_url_valid():
+    result = parse_playlist_url("https://www.deezer.com/en/playlist/1479458365")
+    assert result["valid"] is True
+    assert result["source"] == "deezer"
+    assert result["playlist_id"] == "1479458365"
+
+
+def test_parse_invalid_url():
+    result = parse_playlist_url("https://example.com/not-a-playlist")
+    assert result["valid"] is False
+    assert result["source"] == "unknown"

--- a/tests/test_playlist_parser.py
+++ b/tests/test_playlist_parser.py
@@ -1,12 +1,10 @@
 """Unit tests for playlist URL parser"""
-import pytest
+
 from utils.playlist_parser import parse_playlist_url
 
 
 def test_parse_spotify_url_valid():
-    result = parse_playlist_url(
-        "https://open.spotify.com/playlist/4NDXWHwYWjFmgVPkNy4YlF"
-    )
+    result = parse_playlist_url("https://open.spotify.com/playlist/4NDXWHwYWjFmgVPkNy4YlF")
     assert result["valid"] is True
     assert result["source"] == "spotify"
     assert result["playlist_id"] == "4NDXWHwYWjFmgVPkNy4YlF"

--- a/utils/library_cache_manager.py
+++ b/utils/library_cache_manager.py
@@ -145,27 +145,32 @@ class LibraryCacheManager:
         self, client_type: str, library_key: str = None
     ) -> dict[str, Any] | None:
         """
-        Get library cache data directly from database without requiring client registration
-        Used for status reporting and cache inspection
+        Get library cache data directly from database without triggering a build.
+        Uses resolved library (PLEX_LIBRARY_NAME / Music / first) when client is registered.
 
         Returns:
             Dictionary with cache data or None if not found
         """
         try:
+            cache_key_filter = None
+            if client_type in self.registered_clients:
+                client = self.registered_clients[client_type]
+                resolved_key = library_key
+                if resolved_key is None and hasattr(client, "get_resolved_library_key"):
+                    resolved_key = client.get_resolved_library_key()
+                if resolved_key is not None:
+                    cache_key_filter = client.get_cache_key(resolved_key)
+
             with self.db_manager.get_cache_session_context() as session:
-                # Find the most recent cache entry for this client type
-                cache_entry = (
-                    session.query(LibraryCache)
-                    .filter(
-                        LibraryCache.client_type == client_type,
-                        LibraryCache.expires_at > datetime.utcnow(),
-                    )
-                    .order_by(LibraryCache.created_at.desc())
-                    .first()
+                query = session.query(LibraryCache).filter(
+                    LibraryCache.client_type == client_type,
+                    LibraryCache.expires_at > datetime.utcnow(),
                 )
+                if cache_key_filter:
+                    query = query.filter(LibraryCache.cache_key == cache_key_filter)
+                cache_entry = query.order_by(LibraryCache.created_at.desc()).first()
 
                 if cache_entry:
-                    # Return raw cache data without client processing
                     return cache_entry.cache_data
 
                 return None

--- a/utils/library_selector.py
+++ b/utils/library_selector.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+Library selector utility - single source of truth for resolving which music library
+to use for Plex and Jellyfin operations.
+
+Used for: library cache, play history, track/artist search, sonic analysis.
+Resolution: PLEX_LIBRARY_NAME/JELLYFIN_LIBRARY_NAME if set; else prefer "Music"; else first by lowest key.
+"""
+
+from typing import Any
+
+
+def _first_by_lowest_key(libraries: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Return library with lowest key (numeric when possible)."""
+    if not libraries:
+        return None
+
+    def sort_key(lib):
+        k = lib.get("key") or ""
+        try:
+            return (0, int(k))
+        except ValueError, TypeError:
+            return (1, str(k))
+
+    return min(libraries, key=sort_key)
+
+
+def _resolve_from_libraries(
+    music_libraries: list[dict[str, Any]],
+    name_override: str | None,
+    logger=None,
+) -> dict[str, Any] | None:
+    """
+    Resolve which music library to use. Input is pre-filtered artist-type libraries.
+
+    Order: 1) name_override if set; 2) single library; 3) prefer "Music"; 4) first by lowest key.
+    """
+    if not music_libraries:
+        return None
+    name_override = (name_override or "").strip()
+    chosen = None
+    if name_override:
+        for lib in music_libraries:
+            if (lib.get("title") or "").strip().lower() == name_override.lower():
+                chosen = lib
+                break
+        if not chosen and logger:
+            logger.warning(
+                f"Library '{name_override}' not found in {[item.get('title') for item in music_libraries]}, using first"
+            )
+        if not chosen:
+            chosen = _first_by_lowest_key(music_libraries)
+    elif len(music_libraries) == 1:
+        chosen = music_libraries[0]
+    else:
+        for lib in music_libraries:
+            if (lib.get("title") or "").strip().lower() == "music":
+                chosen = lib
+                break
+        if not chosen:
+            chosen = _first_by_lowest_key(music_libraries)
+    if chosen and logger:
+        logger.debug(f"Resolved library: {chosen.get('title', '?')} (key={chosen.get('key', '?')})")
+    return chosen
+
+
+def resolve_plex_library(client) -> dict[str, Any] | None:
+    """
+    Resolve which Plex music library to use. Uses PLEX_LIBRARY_NAME if set.
+    Returns dict with key, title, type or None.
+    """
+    music_libraries = client.get_music_libraries()
+    name_override = (client.config.get("PLEX_LIBRARY_NAME") or "").strip() or None
+    return _resolve_from_libraries(music_libraries, name_override, client.logger)
+
+
+def resolve_jellyfin_library(client) -> dict[str, Any] | None:
+    """
+    Resolve which Jellyfin music library to use. Uses JELLYFIN_LIBRARY_NAME if set.
+    Returns dict with key, title, type or None.
+    """
+    music_libraries = client.get_music_libraries()
+    name_override = (client.config.get("JELLYFIN_LIBRARY_NAME") or "").strip() or None
+    return _resolve_from_libraries(music_libraries, name_override, client.logger)


### PR DESCRIPTION
## [0.3.8] - 2026-03-09

### 🧪 Unit Tests & CI
- **Unit Tests**: pytest-based tests in `tests/`; start with `parse_playlist_url` (Spotify, Deezer, invalid URLs)
- **CI Gate**: `docker-publish` workflow runs unit tests before Docker build; build fails if tests fail
- **Dev Dependencies**: `requirements-dev.txt` adds pytest and pytest-asyncio

### 🎵 Spotify Scraper Fallback
- **Credential-Based Logic**: Use API when credentials configured; fall back to SpotifyScraper when not configured or API fails (e.g. 403 Premium required)
- **Public Playlists Only**: Scraper and API both support public playlists; no OAuth/private playlist support
- **Feb 2026 API Migration**: Playlist `/items` endpoint, search limit 10, field renames for Development Mode compatibility
- **Execution Failure Fix**: API errors (403, etc.) now correctly mark execution as failed with error message in UI
- **NRD**: Grey out Spotify source when credentials not configured; `new-releases-sources` endpoint for UI
- **NRD Save Validation**: When saving with Spotify source, test API connectivity; reject save if 403 Premium required (prompts use Deezer instead)
- **Test Connectivity**: Spotify "Not configured" shows as warning (orange) instead of error (red)

### 📚 Library Selector – Single Source of Truth
- **Shared Utility**: `utils/library_selector.py` – resolution logic for Plex and Jellyfin; used by all commands
- **Resolution Order**: `PLEX_LIBRARY_NAME` / `JELLYFIN_LIBRARY_NAME` if set; else prefer "Music"; else first by lowest key (type=artist)
- **Cached Keys**: `PLEX_LIBRARY_KEY` and `JELLYFIN_LIBRARY_KEY` (hidden, auto-managed) – resolved on startup and when library cache builder runs
- **Consistent Usage**: Library cache, play history, track/artist search, sonic analysis all use the resolved library
- **No Fallback to Stale**: Commands no longer use stored `target_library_key` from create; always resolve or use cached key

### 🔧 Refactor
- **Clients**: Plex and Jellyfin clients delegate to `resolve_plex_library()` / `resolve_jellyfin_library()`; removed duplicated `_resolve_music_library` and `_first_by_lowest_key`
- **Library Cache Builder**: Uses shared utility; re-resolves and updates cached key on each run
- **Daylist**: Simplified to `get_resolved_library()` instead of direct `_resolve_music_library` call

### 🎵 Artist Discovery Guardrail
- **Max per run**: Per-command limit (default 2) for how many new artists are added to the Playlist Sync Discovery import list per sync run; configurable in create/edit when "Add new artists" is enabled
- **First run**: No artists added on first run—only reports count in execution history; subsequent runs add per limit
- **Always report**: Discovery runs on every successful sync; execution history shows "X new artists detected" regardless of whether adding is enabled
- **UI rename**: Checkbox renamed from "Enable artist discovery" to "Add new artists" with clearer description—discovery always runs to report counts; checkbox controls whether to add to import list