### PR TITLE
Small update, some housekeeping items

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 # Git
 .git
 .gitignore
+.github
 
 # Documentation
 README.md

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# Dependabot configuration
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    target-branch: "develop"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "deps(docker)"

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,5 +1,3 @@
 # Ignored CVEs - revisit when upstream ships a fix
-# CVE-2026-0861: glibc memalign integer overflow - no fix in Debian stable yet (2026-02)
-CVE-2026-0861
 # CVE-2026-4105: systemd RegisterMachine D-Bus privilege escalation (libsystemd0, libudev1) - no fix in Debian stable yet
 CVE-2026-4105

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.11-dev] - TBD
+
+### Housekeeping
+- **Security updates**: Debian 13.4 released on Mar-14, has fix for CVE-2026-0861, and addresses some other lower severity CVEs
+
 ## [0.3.10] - 2026-03-16
 
 ### 🎵 Daylist & Local Discovery

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.11-dev] - TBD
+## [0.3.11] - 2026-03-17
 
 ### Housekeeping
 - **Security updates**: Debian 13.4 released on Mar-14, has fix for CVE-2026-0861, and addresses some other lower severity CVEs
+- **Base image pinning**: Dockerfile updates to pin base image to digest; enablement of dependabot to monitor for digest changes and open PRs
 
 ## [0.3.10] - 2026-03-16
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build React frontend
-FROM node:24-trixie-slim AS frontend-builder
+FROM node:24-trixie-slim@sha256:8c8f12cedb96c3b59642cf30d713943c2b223990c9919b96a141681f62e6e292 AS frontend-builder
 WORKDIR /app/frontend
 COPY frontend/package*.json ./
 RUN npm ci
@@ -7,7 +7,7 @@ COPY frontend/ ./
 RUN npm run build
 
 # Stage 2: Python application
-FROM python:3.14-slim-trixie
+FROM python:3.14-slim-trixie@sha256:584e89d31009a79ae4d9e3ab2fba078524a6c0921cb2711d05e8bb5f628fc9b9
 
 ARG IMAGE_TAG=latest
 ENV CMDARR_IMAGE_TAG=${IMAGE_TAG}
@@ -16,21 +16,21 @@ ENV CMDARR_IMAGE_TAG=${IMAGE_TAG}
 WORKDIR /app
 
 # Set environment variables
-ENV PYTHONUNBUFFERED=1
-ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
 
 # Default PUID/PGID (can be overridden at runtime)
-ENV PUID=1000
-ENV PGID=1000
+ENV PUID=1000 \
+    PGID=1000
 
 # Default application settings
-ENV WEB_HOST=0.0.0.0
-ENV WEB_PORT=8080
-ENV LOG_LEVEL=INFO
-ENV LOG_RETENTION_DAYS=7
+ENV WEB_HOST=0.0.0.0 \
+    WEB_PORT=8080 \
+    LOG_LEVEL=INFO \
+    LOG_RETENTION_DAYS=7
 
 # Install system dependencies
-RUN apt-get update && apt-get upgrade -y && apt-get install -y \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     curl \
     gosu \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ENV LOG_LEVEL=INFO
 ENV LOG_RETENTION_DAYS=7
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     curl \
     gosu \
     && rm -rf /var/lib/apt/lists/*
@@ -39,7 +39,7 @@ RUN apt-get update && apt-get install -y \
 COPY requirements.txt .
 
 # Install Python dependencies
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt
 
 # Copy application code
 COPY . .

--- a/__version__.py
+++ b/__version__.py
@@ -2,4 +2,4 @@
 Cmdarr version information
 """
 
-__version__ = "0.3.11-dev"
+__version__ = "0.3.11"

--- a/__version__.py
+++ b/__version__.py
@@ -2,4 +2,4 @@
 Cmdarr version information
 """
 
-__version__ = "0.3.10"
+__version__ = "0.3.11-dev"

--- a/frontend/src/components/CreatePlaylistSyncDialog.tsx
+++ b/frontend/src/components/CreatePlaylistSyncDialog.tsx
@@ -2076,3 +2076,5 @@ export function CreatePlaylistSyncDialog({
     </Dialog>
   );
 }
+
+}

--- a/frontend/src/components/CreatePlaylistSyncDialog.tsx
+++ b/frontend/src/components/CreatePlaylistSyncDialog.tsx
@@ -2076,5 +2076,3 @@ export function CreatePlaylistSyncDialog({
     </Dialog>
   );
 }
-
-}


### PR DESCRIPTION
## [0.3.11] - 2026-03-17

### Housekeeping
- **Security updates**: Debian 13.4 released on Mar-14, has fix for CVE-2026-0861, and addresses some other lower severity CVEs
- **Base image pinning**: Dockerfile updates to pin base image to digest; enablement of dependabot to monitor for digest changes and open PRs