### PR TITLE
Track Plex/Jellyfin playlists by ID and add in-app delete dialog.

### DIFF
--- a/app/api/commands.py
+++ b/app/api/commands.py
@@ -383,8 +383,13 @@ async def update_command(
                 old_target = str(prev_config_snapshot.get("target", "plex")).lower()
                 new_target = str(merged.get("target", "plex")).lower()
                 if old_last and (old_last != new_title or old_target != new_target):
-                    CommandCleanupService()._delete_playlist_if_exists(old_target, old_last)
+                    CommandCleanupService()._delete_playlist_if_exists(
+                        old_target,
+                        old_last,
+                        playlist_id=prev_config_snapshot.get("last_playlist_id"),
+                    )
                     merged.pop("last_playlist_title", None)
+                    merged.pop("last_playlist_id", None)
                     command.config_json = merged
                 command.display_name = new_title
             elif command_name.startswith("top_tracks_"):
@@ -399,8 +404,13 @@ async def update_command(
                 old_target = str(prev_config_snapshot.get("target", "plex")).lower()
                 new_target = str(merged.get("target", "plex")).lower()
                 if old_last and (old_last != new_title or old_target != new_target):
-                    CommandCleanupService()._delete_playlist_if_exists(old_target, old_last)
+                    CommandCleanupService()._delete_playlist_if_exists(
+                        old_target,
+                        old_last,
+                        playlist_id=prev_config_snapshot.get("last_playlist_id"),
+                    )
                     merged.pop("last_playlist_title", None)
+                    merged.pop("last_playlist_id", None)
                     command.config_json = merged
                 command.display_name = new_title
             elif command_name.startswith("setlistfm_"):
@@ -413,8 +423,13 @@ async def update_command(
                 old_target = str(prev_config_snapshot.get("target", "plex")).lower()
                 new_target = str(merged.get("target", "plex")).lower()
                 if old_last and (old_last != new_title or old_target != new_target):
-                    CommandCleanupService()._delete_playlist_if_exists(old_target, old_last)
+                    CommandCleanupService()._delete_playlist_if_exists(
+                        old_target,
+                        old_last,
+                        playlist_id=prev_config_snapshot.get("last_playlist_id"),
+                    )
                     merged.pop("last_playlist_title", None)
+                    merged.pop("last_playlist_id", None)
                     command.config_json = merged
                 command.display_name = new_title
             # display_name for daylist/local_discovery: sync when plex_history_account_id changes
@@ -2233,7 +2248,11 @@ async def create_listenbrainz_playlist_sync(request: dict, db: Session = Depends
 
 
 @router.delete("/{command_name}")
-async def delete_command(command_name: str, db: Annotated[Session, Depends(get_config_db)]):
+async def delete_command(
+    command_name: str,
+    db: Annotated[Session, Depends(get_config_db)],
+    delete_playlist: bool = Query(False, description="Also delete playlist from configured target"),
+):
     """Delete a command (enhanced to support playlist_sync_* commands)"""
     try:
         # Validate command_name parameter
@@ -2262,6 +2281,11 @@ async def delete_command(command_name: str, db: Annotated[Session, Depends(get_c
             "playlist_sync_discovery_maintenance",
         ]:
             raise HTTPException(status_code=400, detail="Cannot delete built-in commands")
+
+        if delete_playlist:
+            from services.command_cleanup import CommandCleanupService
+
+            CommandCleanupService().delete_playlist_for_command(command)
 
         # Soft delete: keep for 7 days so execution history retains display_name
         command.deleted_at = datetime.utcnow()

--- a/clients/client_jellyfin.py
+++ b/clients/client_jellyfin.py
@@ -1015,12 +1015,14 @@ class JellyfinClient(BaseAPIClient):
 
         return len(intersection) / len(union) if union else 0.0
 
-    def create_playlist_sync(self, title: str, track_ids: list[str], summary: str = "") -> bool:
+    def create_playlist_sync(
+        self, title: str, track_ids: list[str], summary: str = ""
+    ) -> str | None:
         """Create a new playlist with the given tracks using synchronous requests (like Plex)"""
         try:
             if not track_ids:
                 self.logger.warning("No tracks provided for playlist creation")
-                return False
+                return None
 
             self.logger.info(f"Creating playlist '{title}' with {len(track_ids)} tracks")
 
@@ -1072,24 +1074,24 @@ class JellyfinClient(BaseAPIClient):
                             self.logger.warning(
                                 f"Failed to clear cache after creating playlist '{title}': {cache_error}"
                             )
-                    return True
+                    return str(playlist_id)
                 else:
                     self.logger.error(f"Failed to create playlist '{title}' - no ID in response")
-                    return False
+                    return None
             else:
                 self.logger.error(
                     f"Failed to create playlist '{title}' - status {response.status_code}"
                 )
-                return False
+                return None
 
         except requests.exceptions.RequestException as e:
             self.logger.error(f"HTTP error creating playlist '{title}': {e}")
-            return False
+            return None
         except Exception as e:
             self.logger.error(f"Failed to create playlist '{title}': {e}")
-            return False
+            return None
 
-    def create_playlist(self, title: str, track_ids: list[str], summary: str = "") -> bool:
+    def create_playlist(self, title: str, track_ids: list[str], summary: str = "") -> str | None:
         """Create a new playlist with the given tracks"""
         # Use synchronous method for reliability (like Plex)
         return self.create_playlist_sync(title, track_ids, summary)
@@ -1252,6 +1254,22 @@ class JellyfinClient(BaseAPIClient):
         """Find a playlist by name"""
         return self.find_playlist_by_name_sync(playlist_name)
 
+    def get_playlist_by_id(self, playlist_id: str) -> dict[str, Any] | None:
+        """Fetch playlist metadata by Jellyfin Id."""
+        try:
+            headers = {"X-Emby-Token": self.token}
+            response = self._session.get(
+                f"{self.base_url}/Items/{playlist_id}", headers=headers, timeout=30
+            )
+            if response.status_code == 404:
+                return None
+            response.raise_for_status()
+            data = response.json()
+            return data if data.get("Id") else None
+        except Exception as e:
+            self.logger.debug(f"Playlist {playlist_id} not found: {e}")
+            return None
+
     def delete_playlist_sync(self, playlist_id: str) -> bool:
         """Delete a playlist by ID using synchronous requests"""
         try:
@@ -1412,12 +1430,15 @@ class JellyfinClient(BaseAPIClient):
             return False
 
     def create_or_update_playlist_sync(
-        self, title: str, track_ids: list[str], summary: str = ""
-    ) -> bool:
+        self,
+        title: str,
+        track_ids: list[str],
+        summary: str = "",
+        existing_playlist_id: str | None = None,
+    ) -> str | None:
         """
         Create a new playlist or update an existing one with the same name.
-        Enhanced with playlist validation to avoid unnecessary recreation.
-        Handles multiple duplicates by deleting ALL existing playlists with the same name.
+        Returns playlist Id on success, None on failure.
         """
         try:
             # Validate input track IDs
@@ -1425,7 +1446,7 @@ class JellyfinClient(BaseAPIClient):
                 self.logger.warning(
                     f"No track IDs provided for playlist '{title}', skipping creation"
                 )
-                return False
+                return None
 
             # Filter out None values and validate track IDs
             valid_track_ids = [tid for tid in track_ids if tid is not None and tid.strip()]
@@ -1433,15 +1454,20 @@ class JellyfinClient(BaseAPIClient):
                 self.logger.warning(
                     f"No valid track IDs provided for playlist '{title}', skipping creation"
                 )
-                return False
+                return None
 
             if len(valid_track_ids) != len(track_ids):
                 self.logger.warning(
                     f"Filtered out {len(track_ids) - len(valid_track_ids)} invalid track IDs for playlist '{title}'"
                 )
 
-            # Check if playlists with this name already exist
-            existing_playlists = self.find_all_playlists_by_name_sync(title)
+            existing_playlists: list[dict[str, Any]] = []
+            if existing_playlist_id:
+                pl = self.get_playlist_by_id(existing_playlist_id)
+                if pl:
+                    existing_playlists = [pl]
+            if not existing_playlists:
+                existing_playlists = self.find_all_playlists_by_name_sync(title)
 
             if existing_playlists:
                 self.logger.info(
@@ -1466,7 +1492,7 @@ class JellyfinClient(BaseAPIClient):
                                     f"Deleting duplicate playlist '{title}' (ID: {other_playlist['Id']})"
                                 )
                                 self.delete_playlist_sync(other_playlist["Id"])
-                        return True
+                        return str(existing_playlist["Id"])
 
                 # Check if any existing playlist has tracks (not empty)
                 has_existing_tracks = False
@@ -1495,7 +1521,8 @@ class JellyfinClient(BaseAPIClient):
                                 f"Deleting empty duplicate playlist '{title}' (ID: {other_playlist['Id']})"
                             )
                             self.delete_playlist_sync(other_playlist["Id"])
-                    return True
+                    kept_id = existing_playlists[0]["Id"]
+                    return str(kept_id)
 
                 # No existing playlist has tracks, delete all existing ones and create new
                 self.logger.info(
@@ -1509,7 +1536,7 @@ class JellyfinClient(BaseAPIClient):
                         self.logger.error(
                             f"Failed to delete existing playlist {existing_playlist['Id']}"
                         )
-                        return False
+                        return None
 
                 # Wait a moment for deletions to complete
                 import time
@@ -1521,7 +1548,7 @@ class JellyfinClient(BaseAPIClient):
 
         except Exception as e:
             self.logger.error(f"Error creating or updating playlist '{title}': {e}")
-            return False
+            return None
 
     def sync_playlist(
         self, title: str, tracks: list[dict[str, Any]], summary: str = "", **kwargs
@@ -1588,9 +1615,12 @@ class JellyfinClient(BaseAPIClient):
             track_ids = [track["id"] for track in found_tracks]
 
             # Use the create_or_update_playlist_sync method for proper playlist management
-            success = self.create_or_update_playlist_sync(title, track_ids, summary)
+            existing_playlist_id = kwargs.get("existing_playlist_id")
+            playlist_id = self.create_or_update_playlist_sync(
+                title, track_ids, summary, existing_playlist_id=existing_playlist_id
+            )
 
-            if success:
+            if playlist_id:
                 # Always report the actual tracks that were processed (like Plex does)
                 match_rate = (len(found_tracks) / len(tracks) * 100) if len(tracks) > 0 else 0
                 self.logger.info(
@@ -1599,6 +1629,8 @@ class JellyfinClient(BaseAPIClient):
                 return {
                     "success": True,
                     "action": "synced",
+                    "playlist_id": playlist_id,
+                    "playlist_title": title,
                     "total_tracks": len(tracks),
                     "found_tracks": len(found_tracks),
                     "unmatched_tracks": unmatched_tracks,
@@ -1608,6 +1640,8 @@ class JellyfinClient(BaseAPIClient):
                 return {
                     "success": False,
                     "action": "failed",
+                    "playlist_id": None,
+                    "playlist_title": title,
                     "total_tracks": len(tracks),
                     "found_tracks": len(found_tracks),
                     "unmatched_tracks": unmatched_tracks,

--- a/clients/client_plex.py
+++ b/clients/client_plex.py
@@ -875,9 +875,15 @@ class PlexClient(BaseAPIClient):
                     }
 
             # Create/update playlist using proven method
-            success = self.create_or_update_playlist(title, found_track_keys, summary)
+            existing_playlist_id = kwargs.get("existing_playlist_id")
+            playlist_id = self.create_or_update_playlist(
+                title,
+                found_track_keys,
+                summary,
+                existing_playlist_id=existing_playlist_id,
+            )
 
-            if success:
+            if playlist_id:
                 match_rate = (tracks_found / tracks_total * 100) if tracks_total > 0 else 0
                 self.logger.info(
                     f"Successfully synced playlist '{title}': {tracks_found}/{tracks_total} tracks ({match_rate:.1f}% success rate)"
@@ -885,6 +891,8 @@ class PlexClient(BaseAPIClient):
                 return {
                     "success": True,
                     "action": "synced",
+                    "playlist_id": playlist_id,
+                    "playlist_title": title,
                     "total_tracks": tracks_total,
                     "found_tracks": tracks_found,
                     "unmatched_tracks": failed_matches,
@@ -895,6 +903,8 @@ class PlexClient(BaseAPIClient):
                 return {
                     "success": False,
                     "action": "failed",
+                    "playlist_id": None,
+                    "playlist_title": title,
                     "total_tracks": tracks_total,
                     "found_tracks": tracks_found,
                     "unmatched_tracks": failed_matches,
@@ -1830,6 +1840,21 @@ class PlexClient(BaseAPIClient):
             self.logger.error(f"Error finding playlist by name: {e}")
             return None
 
+    def get_playlist_by_id(self, playlist_rating_key: str | int) -> dict[str, Any] | None:
+        """Fetch playlist metadata by Plex ratingKey."""
+        try:
+            result = self._get(f"/playlists/{playlist_rating_key}")
+            media_container = result.get("MediaContainer", {})
+            metadata = media_container.get("Metadata", [])
+            if metadata:
+                return metadata[0]
+            if media_container.get("ratingKey"):
+                return media_container
+            return None
+        except Exception as e:
+            self.logger.debug(f"Playlist {playlist_rating_key} not found: {e}")
+            return None
+
     def find_playlist_by_prefix(self, prefix: str):
         """Find a playlist whose title starts with prefix. Returns first match or None."""
         try:
@@ -1875,7 +1900,7 @@ class PlexClient(BaseAPIClient):
         try:
             if not track_rating_keys:
                 self.logger.warning("No tracks provided for playlist creation")
-                return False
+                return None
 
             self.logger.info(
                 f"Creating playlist '{title}' using hybrid method (1 track + add remaining)..."
@@ -1907,7 +1932,7 @@ class PlexClient(BaseAPIClient):
 
             if not created_playlist:
                 self.logger.error("Could not find created playlist")
-                return False
+                return None
 
             playlist_rating_key = created_playlist["ratingKey"]
 
@@ -1927,11 +1952,11 @@ class PlexClient(BaseAPIClient):
             self.logger.info(
                 f"Successfully created playlist '{title}' with {len(track_rating_keys)} tracks total"
             )
-            return True
+            return str(playlist_rating_key)
 
         except Exception as e:
             self.logger.error(f"Error creating playlist '{title}': {e}")
-            return False
+            return None
 
     def add_tracks_to_playlist(self, playlist_rating_key, track_rating_keys):
         """
@@ -2000,17 +2025,28 @@ class PlexClient(BaseAPIClient):
             return False
 
     def create_or_update_playlist(
-        self, title, track_rating_keys, summary="", match_prefix: str | None = None
-    ):
+        self,
+        title,
+        track_rating_keys,
+        summary="",
+        match_prefix: str | None = None,
+        existing_playlist_id: str | None = None,
+    ) -> str | None:
         """
         Create a new playlist or update an existing one.
+        Returns playlist ratingKey on success, None on failure.
+        If existing_playlist_id is set, prefer that playlist over name lookup.
         If match_prefix is set (e.g. '[Cmdarr] Daylist'), find existing by prefix instead of exact title.
         """
         try:
-            if match_prefix:
-                existing_playlist = self.find_playlist_by_prefix(match_prefix)
-            else:
-                existing_playlist = self.find_playlist_by_name(title)
+            existing_playlist = None
+            if existing_playlist_id:
+                existing_playlist = self.get_playlist_by_id(existing_playlist_id)
+            if not existing_playlist:
+                if match_prefix:
+                    existing_playlist = self.find_playlist_by_prefix(match_prefix)
+                else:
+                    existing_playlist = self.find_playlist_by_name(title)
 
             if existing_playlist:
                 self.logger.info(f"Found existing playlist '{title}', validating content...")
@@ -2025,12 +2061,12 @@ class PlexClient(BaseAPIClient):
                     self.logger.info(
                         f"Playlist '{title}' already exists with identical content, skipping recreation"
                     )
-                    return True
+                    return str(existing_playlist["ratingKey"])
                 else:
                     self.logger.info(f"Playlist '{title}' content differs, updating playlist")
                     if not self.delete_playlist(existing_playlist["ratingKey"]):
                         self.logger.error("Failed to delete existing playlist")
-                        return False
+                        return None
 
                     # Wait a moment for deletion to complete
                     time.sleep(2)
@@ -2040,7 +2076,7 @@ class PlexClient(BaseAPIClient):
 
         except Exception as e:
             self.logger.error(f"Error creating or updating playlist '{title}': {e}")
-            return False
+            return None
 
     def get_playlist_tracks(self, playlist_rating_key):
         """Get all tracks in a playlist for verification purposes."""

--- a/commands/playlist_generator_helpers.py
+++ b/commands/playlist_generator_helpers.py
@@ -218,3 +218,84 @@ def compute_top_tracks_playlist_title_from_config(config: dict[str, Any]) -> str
     else:
         suffix = build_auto_playlist_suffix(names[:50]) if names else "Mix"
     return f"{PLAYLIST_TITLE_TOP_TRACKS_PREFIX}: {suffix}"
+
+
+def persist_playlist_identity(
+    command_name: str,
+    command_name_prefix: str,
+    playlist_title: str,
+    playlist_id: str | None,
+    logger: Any,
+    *,
+    update_display_name: bool = True,
+) -> None:
+    """Persist last_playlist_title and last_playlist_id on CommandConfig after a successful sync."""
+    if not command_name or not command_name.startswith(command_name_prefix):
+        return
+    try:
+        from database.config_models import CommandConfig
+        from database.database import get_database_manager
+
+        db = get_database_manager()
+        session = db.get_config_session_sync()
+        try:
+            cmd = (
+                session.query(CommandConfig)
+                .filter(CommandConfig.command_name == command_name)
+                .first()
+            )
+            if cmd:
+                cfg = dict(cmd.config_json or {})
+                cfg["last_playlist_title"] = playlist_title
+                if playlist_id:
+                    cfg["last_playlist_id"] = str(playlist_id)
+                else:
+                    cfg.pop("last_playlist_id", None)
+                cmd.config_json = cfg
+                if update_display_name:
+                    cmd.display_name = playlist_title
+                session.commit()
+        finally:
+            session.close()
+    except Exception as e:
+        logger.warning(f"Could not persist playlist identity: {e}")
+
+
+def delete_playlist_on_target(
+    target_client: Any,
+    *,
+    playlist_id: str | None = None,
+    playlist_title: str | None = None,
+    logger: Any | None = None,
+) -> None:
+    """Delete a playlist by stored ID (preferred) or by name fallback."""
+    log = logger
+    try:
+        if playlist_id:
+            if hasattr(target_client, "get_playlist_by_id"):
+                pl = target_client.get_playlist_by_id(playlist_id)
+                if pl:
+                    if pl.get("ratingKey"):
+                        target_client.delete_playlist(pl["ratingKey"])
+                    elif pl.get("Id"):
+                        target_client.delete_playlist(pl["Id"])
+                    if log:
+                        log.info(f"Deleted playlist by id {playlist_id}")
+                    return
+            if hasattr(target_client, "delete_playlist"):
+                target_client.delete_playlist(playlist_id)
+                if log:
+                    log.info(f"Deleted playlist by id {playlist_id}")
+                return
+        if playlist_title and hasattr(target_client, "find_playlist_by_name"):
+            pl = target_client.find_playlist_by_name(playlist_title)
+            if pl:
+                if pl.get("ratingKey"):
+                    target_client.delete_playlist(pl["ratingKey"])
+                elif pl.get("Id"):
+                    target_client.delete_playlist(pl["Id"])
+                if log:
+                    log.info(f"Deleted playlist '{playlist_title}' (name fallback)")
+    except Exception as e:
+        if log:
+            log.warning(f"Could not delete playlist: {e}")

--- a/commands/playlist_generator_lfm_similar.py
+++ b/commands/playlist_generator_lfm_similar.py
@@ -15,6 +15,8 @@ from .command_base import BaseCommand
 from .playlist_generator_helpers import (
     build_lfm_similar_artist_pool,
     compute_lfm_similar_playlist_title,
+    delete_playlist_on_target,
+    persist_playlist_identity,
     validate_artists_against_cache,
 )
 
@@ -46,53 +48,6 @@ class PlaylistGeneratorLfmSimilarCommand(BaseCommand):
         if target == "jellyfin":
             return JellyfinClient(self.config), "Jellyfin"
         return self.plex_client, "Plex"
-
-    def _delete_playlist_by_name(
-        self, target_client: PlexClient | JellyfinClient, playlist_title: str
-    ) -> None:
-        try:
-            pl = target_client.find_playlist_by_name(playlist_title)
-            if not pl:
-                return
-            if isinstance(target_client, PlexClient):
-                rk = pl.get("ratingKey")
-                if rk:
-                    target_client.delete_playlist(rk)
-                    self.logger.info(f"Deleted old playlist '{playlist_title}' (name changed)")
-            else:
-                pid = pl.get("Id")
-                if pid:
-                    target_client.delete_playlist(pid)
-                    self.logger.info(f"Deleted old playlist '{playlist_title}' (name changed)")
-        except Exception as e:
-            self.logger.warning(f"Could not delete old playlist '{playlist_title}': {e}")
-
-    def _persist_after_success(self, playlist_title: str) -> None:
-        try:
-            from database.config_models import CommandConfig
-            from database.database import get_database_manager
-
-            cmd_name = self.config_json.get("command_name", "")
-            if not cmd_name or not cmd_name.startswith("lfm_similar_"):
-                return
-            db = get_database_manager()
-            session = db.get_config_session_sync()
-            try:
-                cmd = (
-                    session.query(CommandConfig)
-                    .filter(CommandConfig.command_name == cmd_name)
-                    .first()
-                )
-                if cmd:
-                    cfg = dict(cmd.config_json or {})
-                    cfg["last_playlist_title"] = playlist_title
-                    cmd.config_json = cfg
-                    cmd.display_name = playlist_title
-                    session.commit()
-            finally:
-                session.close()
-        except Exception as e:
-            self.logger.warning(f"Could not persist after success: {e}")
 
     async def execute(self) -> bool:
         try:
@@ -184,8 +139,15 @@ class PlaylistGeneratorLfmSimilarCommand(BaseCommand):
 
             playlist_title = compute_lfm_similar_playlist_title(config)
             last_playlist_title = config.get("last_playlist_title")
-            if last_playlist_title and last_playlist_title != playlist_title:
-                self._delete_playlist_by_name(target_client, last_playlist_title)
+            last_playlist_id = config.get("last_playlist_id")
+            title_changed = last_playlist_title and last_playlist_title != playlist_title
+            if title_changed:
+                delete_playlist_on_target(
+                    target_client,
+                    playlist_id=str(last_playlist_id) if last_playlist_id else None,
+                    playlist_title=last_playlist_title,
+                    logger=self.logger,
+                )
 
             tracks_for_playlist: list[dict[str, Any]] = []
             artists_processed = 0
@@ -231,6 +193,7 @@ class PlaylistGeneratorLfmSimilarCommand(BaseCommand):
                 summary=summary,
                 library_cache_manager=self.library_cache_manager,
                 library_key=library_key,
+                existing_playlist_id=None if title_changed else last_playlist_id,
             )
 
             success = result.get("success", False)
@@ -257,7 +220,13 @@ class PlaylistGeneratorLfmSimilarCommand(BaseCommand):
                     f"Created playlist '{playlist_title}': {found}/{total} tracks from "
                     f"{artists_processed} artists"
                 )
-                self._persist_after_success(playlist_title)
+                persist_playlist_identity(
+                    self.config_json.get("command_name", ""),
+                    "lfm_similar_",
+                    playlist_title,
+                    result.get("playlist_id"),
+                    self.logger,
+                )
             return success
 
         except Exception as e:

--- a/commands/playlist_generator_mood.py
+++ b/commands/playlist_generator_mood.py
@@ -13,6 +13,7 @@ from clients.client_plex import PlexClient
 from utils.library_cache_manager import get_library_cache_manager
 
 from .command_base import BaseCommand
+from .playlist_generator_helpers import delete_playlist_on_target, persist_playlist_identity
 
 PLAYLIST_TITLE_PREFIX = "[Cmdarr] Mood"
 SEP = " · "
@@ -71,44 +72,6 @@ class PlaylistGeneratorMoodCommand(BaseCommand):
                 session.close()
         except Exception as e:
             self.logger.warning(f"Could not persist last_run_track_ids: {e}")
-
-    def _persist_after_success(self, playlist_title: str) -> None:
-        """Persist last_playlist_title and update display_name to match playlist."""
-        try:
-            from database.config_models import CommandConfig
-            from database.database import get_database_manager
-
-            cmd_name = self.config_json.get("command_name", "")
-            if not cmd_name or not cmd_name.startswith("mood_playlist_"):
-                return
-            db = get_database_manager()
-            session = db.get_config_session_sync()
-            try:
-                cmd = (
-                    session.query(CommandConfig)
-                    .filter(CommandConfig.command_name == cmd_name)
-                    .first()
-                )
-                if cmd:
-                    cfg = dict(cmd.config_json or {})
-                    cfg["last_playlist_title"] = playlist_title
-                    cmd.config_json = cfg
-                    cmd.display_name = playlist_title
-                    session.commit()
-            finally:
-                session.close()
-        except Exception as e:
-            self.logger.warning(f"Could not persist after success: {e}")
-
-    def _delete_playlist_by_name(self, playlist_title: str) -> None:
-        """Delete a playlist by name from Plex (mood playlists are Plex-only)."""
-        try:
-            pl = self.plex_client.find_playlist_by_name(playlist_title)
-            if pl and pl.get("ratingKey"):
-                self.plex_client.delete_playlist(pl["ratingKey"])
-                self.logger.info(f"Deleted old playlist '{playlist_title}' (name changed)")
-        except Exception as e:
-            self.logger.warning(f"Could not delete old playlist '{playlist_title}': {e}")
 
     async def execute(self) -> bool:
         try:
@@ -235,8 +198,15 @@ class PlaylistGeneratorMoodCommand(BaseCommand):
             # 4. Create playlist
             playlist_title = f"{PLAYLIST_TITLE_PREFIX}: {suffix}"
             last_playlist_title = config.get("last_playlist_title")
-            if last_playlist_title and last_playlist_title != playlist_title:
-                self._delete_playlist_by_name(last_playlist_title)
+            last_playlist_id = config.get("last_playlist_id")
+            title_changed = last_playlist_title and last_playlist_title != playlist_title
+            if title_changed:
+                delete_playlist_on_target(
+                    self.plex_client,
+                    playlist_id=str(last_playlist_id) if last_playlist_id else None,
+                    playlist_title=last_playlist_title,
+                    logger=self.logger,
+                )
             summary = f"Moods: {', '.join(moods[:5])}{'...' if len(moods) > 5 else ''}"
 
             result = self.plex_client.sync_playlist(
@@ -244,12 +214,19 @@ class PlaylistGeneratorMoodCommand(BaseCommand):
                 tracks=sampled_deduped,
                 summary=summary,
                 library_key=library_key,
+                existing_playlist_id=None if title_changed else last_playlist_id,
             )
 
             success = result.get("success", False)
             if success:
                 self._persist_last_run_track_ids([t["rating_key"] for t in sampled_deduped])
-                self._persist_after_success(playlist_title)
+                persist_playlist_identity(
+                    self.config_json.get("command_name", ""),
+                    "mood_playlist_",
+                    playlist_title,
+                    result.get("playlist_id"),
+                    self.logger,
+                )
                 self.logger.info(
                     f"Created playlist '{playlist_title}': {len(sampled_deduped)} tracks from {len(moods)} moods"
                 )

--- a/commands/playlist_generator_setlistfm.py
+++ b/commands/playlist_generator_setlistfm.py
@@ -29,7 +29,9 @@ from utils.text_normalizer import normalize_text
 from .command_base import BaseCommand
 from .playlist_generator_helpers import (
     compute_setlistfm_playlist_title,
+    delete_playlist_on_target,
     load_lidarr_artist_norm_mbid_index_sync,
+    persist_playlist_identity,
     validate_artists_against_cache,
 )
 
@@ -57,53 +59,6 @@ class PlaylistGeneratorSetlistfmCommand(BaseCommand):
         if target == "jellyfin":
             return JellyfinClient(self.config), "Jellyfin"
         return self.plex_client, "Plex"
-
-    def _delete_playlist_by_name(
-        self, target_client: PlexClient | JellyfinClient, playlist_title: str
-    ) -> None:
-        try:
-            pl = target_client.find_playlist_by_name(playlist_title)
-            if not pl:
-                return
-            if isinstance(target_client, PlexClient):
-                rk = pl.get("ratingKey")
-                if rk:
-                    target_client.delete_playlist(rk)
-                    self.logger.info(f"Deleted old playlist '{playlist_title}' (name changed)")
-            else:
-                pid = pl.get("Id")
-                if pid:
-                    target_client.delete_playlist(pid)
-                    self.logger.info(f"Deleted old playlist '{playlist_title}' (name changed)")
-        except Exception as e:
-            self.logger.warning(f"Could not delete old playlist '{playlist_title}': {e}")
-
-    def _persist_after_success(self, playlist_title: str) -> None:
-        try:
-            from database.config_models import CommandConfig
-            from database.database import get_database_manager
-
-            cmd_name = self.config_json.get("command_name", "")
-            if not cmd_name or not cmd_name.startswith("setlistfm_"):
-                return
-            db = get_database_manager()
-            session = db.get_config_session_sync()
-            try:
-                cmd = (
-                    session.query(CommandConfig)
-                    .filter(CommandConfig.command_name == cmd_name)
-                    .first()
-                )
-                if cmd:
-                    cfg = dict(cmd.config_json or {})
-                    cfg["last_playlist_title"] = playlist_title
-                    cmd.config_json = cfg
-                    cmd.display_name = playlist_title
-                    session.commit()
-            finally:
-                session.close()
-        except Exception as e:
-            self.logger.warning(f"Could not persist after success: {e}")
 
     async def _resolve_songs_for_artist(
         self,
@@ -230,8 +185,15 @@ class PlaylistGeneratorSetlistfmCommand(BaseCommand):
 
             playlist_title = compute_setlistfm_playlist_title(config)
             last_playlist_title = config.get("last_playlist_title")
-            if last_playlist_title and last_playlist_title != playlist_title:
-                self._delete_playlist_by_name(target_client, last_playlist_title)
+            last_playlist_id = config.get("last_playlist_id")
+            title_changed = last_playlist_title and last_playlist_title != playlist_title
+            if title_changed:
+                delete_playlist_on_target(
+                    target_client,
+                    playlist_id=str(last_playlist_id) if last_playlist_id else None,
+                    playlist_title=last_playlist_title,
+                    logger=self.logger,
+                )
 
             tracks_for_playlist: list[dict[str, Any]] = []
             artists_processed = 0
@@ -288,6 +250,7 @@ class PlaylistGeneratorSetlistfmCommand(BaseCommand):
                 summary=summary,
                 library_cache_manager=self.library_cache_manager,
                 library_key=library_key,
+                existing_playlist_id=None if title_changed else last_playlist_id,
             )
 
             success = result.get("success", False)
@@ -310,7 +273,13 @@ class PlaylistGeneratorSetlistfmCommand(BaseCommand):
                     f"Created playlist '{playlist_title}': {found}/{total} tracks from "
                     f"{artists_processed} artists"
                 )
-                self._persist_after_success(playlist_title)
+                persist_playlist_identity(
+                    self.config_json.get("command_name", ""),
+                    "setlistfm_",
+                    playlist_title,
+                    result.get("playlist_id"),
+                    self.logger,
+                )
             return success
 
         except Exception as e:

--- a/commands/playlist_generator_top_tracks.py
+++ b/commands/playlist_generator_top_tracks.py
@@ -13,7 +13,12 @@ from utils.library_cache_manager import get_library_cache_manager
 from utils.text_normalizer import normalize_text
 
 from .command_base import BaseCommand
-from .playlist_generator_helpers import build_auto_playlist_suffix, validate_artists_against_cache
+from .playlist_generator_helpers import (
+    build_auto_playlist_suffix,
+    delete_playlist_on_target,
+    persist_playlist_identity,
+    validate_artists_against_cache,
+)
 
 PLAYLIST_TITLE_PREFIX = "[Cmdarr] Artist Essentials"
 
@@ -42,55 +47,6 @@ class PlaylistGeneratorTopTracksCommand(BaseCommand):
         if target == "jellyfin":
             return JellyfinClient(self.config), "Jellyfin"
         return self.plex_client, "Plex"
-
-    def _delete_playlist_by_name(
-        self, target_client: PlexClient | JellyfinClient, playlist_title: str
-    ) -> None:
-        """Delete a playlist by name from Plex or Jellyfin."""
-        try:
-            pl = target_client.find_playlist_by_name(playlist_title)
-            if not pl:
-                return
-            if isinstance(target_client, PlexClient):
-                rk = pl.get("ratingKey")
-                if rk:
-                    target_client.delete_playlist(rk)
-                    self.logger.info(f"Deleted old playlist '{playlist_title}' (name changed)")
-            else:
-                pid = pl.get("Id")
-                if pid:
-                    target_client.delete_playlist(pid)
-                    self.logger.info(f"Deleted old playlist '{playlist_title}' (name changed)")
-        except Exception as e:
-            self.logger.warning(f"Could not delete old playlist '{playlist_title}': {e}")
-
-    def _persist_after_success(self, playlist_title: str) -> None:
-        """Persist last_playlist_title and update display_name to match playlist."""
-        try:
-            from database.config_models import CommandConfig
-            from database.database import get_database_manager
-
-            cmd_name = self.config_json.get("command_name", "")
-            if not cmd_name or not cmd_name.startswith("top_tracks_"):
-                return
-            db = get_database_manager()
-            session = db.get_config_session_sync()
-            try:
-                cmd = (
-                    session.query(CommandConfig)
-                    .filter(CommandConfig.command_name == cmd_name)
-                    .first()
-                )
-                if cmd:
-                    cfg = dict(cmd.config_json or {})
-                    cfg["last_playlist_title"] = playlist_title
-                    cmd.config_json = cfg
-                    cmd.display_name = playlist_title
-                    session.commit()
-            finally:
-                session.close()
-        except Exception as e:
-            self.logger.warning(f"Could not persist after success: {e}")
 
     async def execute(self) -> bool:
         try:
@@ -152,8 +108,15 @@ class PlaylistGeneratorTopTracksCommand(BaseCommand):
                 suffix = build_auto_playlist_suffix(ordered_display_names)
             playlist_title = f"{PLAYLIST_TITLE_PREFIX}: {suffix}"
             last_playlist_title = config.get("last_playlist_title")
-            if last_playlist_title and last_playlist_title != playlist_title:
-                self._delete_playlist_by_name(target_client, last_playlist_title)
+            last_playlist_id = config.get("last_playlist_id")
+            title_changed = last_playlist_title and last_playlist_title != playlist_title
+            if title_changed:
+                delete_playlist_on_target(
+                    target_client,
+                    playlist_id=str(last_playlist_id) if last_playlist_id else None,
+                    playlist_title=last_playlist_title,
+                    logger=self.logger,
+                )
 
             tracks_for_playlist: list[dict[str, Any]] = []
             artists_processed = 0
@@ -224,6 +187,7 @@ class PlaylistGeneratorTopTracksCommand(BaseCommand):
                 summary=summary,
                 library_cache_manager=self.library_cache_manager,
                 library_key=library_key,
+                existing_playlist_id=None if title_changed else last_playlist_id,
             )
 
             success = result.get("success", False)
@@ -247,7 +211,13 @@ class PlaylistGeneratorTopTracksCommand(BaseCommand):
                 self.logger.info(
                     f"Created playlist '{playlist_title}': {found}/{total} tracks from {artists_processed} artists"
                 )
-                self._persist_after_success(playlist_title)
+                persist_playlist_identity(
+                    self.config_json.get("command_name", ""),
+                    "top_tracks_",
+                    playlist_title,
+                    result.get("playlist_id"),
+                    self.logger,
+                )
             return success
 
         except Exception as e:

--- a/commands/playlist_generator_xmplaylist.py
+++ b/commands/playlist_generator_xmplaylist.py
@@ -15,6 +15,7 @@ from utils.library_cache_manager import get_library_cache_manager
 from utils.text_normalizer import normalize_text
 
 from .command_base import BaseCommand
+from .playlist_generator_helpers import delete_playlist_on_target, persist_playlist_identity
 
 
 def _dedupe_tracks(tracks: list[dict[str, str]]) -> list[dict[str, str]]:
@@ -147,50 +148,6 @@ class PlaylistGeneratorXmplaylistCommand(BaseCommand):
             return JellyfinClient(self.config), "jellyfin"
         return self.plex_client, "plex"
 
-    def _delete_playlist_by_name(
-        self, target_client: PlexClient | JellyfinClient, playlist_title: str
-    ) -> None:
-        try:
-            pl = target_client.find_playlist_by_name(playlist_title)
-            if not pl:
-                return
-            if isinstance(target_client, PlexClient):
-                rk = pl.get("ratingKey")
-                if rk:
-                    target_client.delete_playlist(rk)
-            else:
-                pid = pl.get("Id")
-                if pid:
-                    target_client.delete_playlist(pid)
-        except Exception as e:
-            self.logger.warning(f"Could not delete old playlist '{playlist_title}': {e}")
-
-    def _persist_after_success(self, sync_playlist_title: str) -> None:
-        try:
-            from database.config_models import CommandConfig
-            from database.database import get_database_manager
-
-            cmd_name = self.config_json.get("command_name", "")
-            if not cmd_name or not cmd_name.startswith("xmplaylist_"):
-                return
-            db = get_database_manager()
-            session = db.get_config_session_sync()
-            try:
-                cmd = (
-                    session.query(CommandConfig)
-                    .filter(CommandConfig.command_name == cmd_name)
-                    .first()
-                )
-                if cmd:
-                    cfg = dict(cmd.config_json or {})
-                    cfg["last_playlist_title"] = sync_playlist_title
-                    cmd.config_json = cfg
-                    session.commit()
-            finally:
-                session.close()
-        except Exception as e:
-            self.logger.warning(f"Could not persist after success: {e}")
-
     def _register_for_library_cache(
         self, target_key: str, register_client: PlexClient | JellyfinClient
     ) -> None:
@@ -279,8 +236,10 @@ class PlaylistGeneratorXmplaylistCommand(BaseCommand):
                 return True
 
             sync_title = _build_xmplaylist_sync_title(cfg)
-            last_title = cfg.get("last_playlist_title")
-            if last_title and last_title != sync_title:
+            last_playlist_title = cfg.get("last_playlist_title")
+            last_playlist_id = cfg.get("last_playlist_id")
+            title_changed = last_playlist_title and last_playlist_title != sync_title
+            if title_changed:
                 if multi_plex:
                     from utils.plex_user import get_token_for_user
 
@@ -289,9 +248,19 @@ class PlaylistGeneratorXmplaylistCommand(BaseCommand):
                         pc_del = (
                             PlexClient(self.config, token_override=tok) if tok else self.plex_client
                         )
-                        self._delete_playlist_by_name(pc_del, last_title)
+                        delete_playlist_on_target(
+                            pc_del,
+                            playlist_id=str(last_playlist_id) if last_playlist_id else None,
+                            playlist_title=last_playlist_title,
+                            logger=self.logger,
+                        )
                 else:
-                    self._delete_playlist_by_name(target_client, last_title)
+                    delete_playlist_on_target(
+                        target_client,
+                        playlist_id=str(last_playlist_id) if last_playlist_id else None,
+                        playlist_title=last_playlist_title,
+                        logger=self.logger,
+                    )
 
             if kind == "most_heard":
                 summary = f"SiriusXM via xmplaylist.com — most played ({most_days}d)"
@@ -345,6 +314,7 @@ class PlaylistGeneratorXmplaylistCommand(BaseCommand):
                         summary=summary,
                         library_cache_manager=self.library_cache_manager,
                         library_key=library_key,
+                        existing_playlist_id=None if title_changed else last_playlist_id,
                     )
                     if not bool(result.get("success")):
                         all_ok = False
@@ -362,6 +332,7 @@ class PlaylistGeneratorXmplaylistCommand(BaseCommand):
                     summary=summary,
                     library_cache_manager=self.library_cache_manager,
                     library_key=library_key,
+                    existing_playlist_id=None if title_changed else last_playlist_id,
                 )
 
                 success = bool(result.get("success"))
@@ -428,7 +399,14 @@ class PlaylistGeneratorXmplaylistCommand(BaseCommand):
 
             if success:
                 self.logger.info(f"XM playlist '{sync_title}': {found}/{total} tracks matched")
-                self._persist_after_success(sync_title)
+                persist_playlist_identity(
+                    self.config_json.get("command_name", ""),
+                    "xmplaylist_",
+                    sync_title,
+                    result.get("playlist_id"),
+                    self.logger,
+                    update_display_name=False,
+                )
             else:
                 self.last_run_stats["error"] = result.get("message") or "sync_playlist failed"
 

--- a/frontend/src/components/DeleteCommandDialog.tsx
+++ b/frontend/src/components/DeleteCommandDialog.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+
+function commandCreatesPlaylist(commandName: string): boolean {
+  return (
+    commandName.startsWith("playlist_sync_") ||
+    commandName.startsWith("top_tracks_") ||
+    commandName.startsWith("lfm_similar_") ||
+    commandName.startsWith("setlistfm_") ||
+    commandName.startsWith("mood_playlist_") ||
+    commandName.startsWith("xmplaylist_") ||
+    commandName.startsWith("daylist_") ||
+    commandName.startsWith("local_discovery_")
+  );
+}
+
+type DeleteCommandDialogProps = {
+  open: boolean;
+  commandName: string | null;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (deletePlaylist: boolean) => void | Promise<void>;
+  isDeleting?: boolean;
+};
+
+export function DeleteCommandDialog({
+  open,
+  commandName,
+  onOpenChange,
+  onConfirm,
+  isDeleting = false,
+}: DeleteCommandDialogProps) {
+  const [deletePlaylist, setDeletePlaylist] = useState(false);
+
+  const showPlaylistOption = commandName ? commandCreatesPlaylist(commandName) : false;
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) setDeletePlaylist(false);
+    onOpenChange(next);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete command</DialogTitle>
+          <DialogDescription>
+            {commandName
+              ? `Are you sure you want to delete "${commandName}"? This cannot be undone.`
+              : "Are you sure you want to delete this command? This cannot be undone."}
+          </DialogDescription>
+        </DialogHeader>
+        {showPlaylistOption && (
+          <div className="flex items-start gap-2 py-2">
+            <input
+              type="checkbox"
+              id="delete-playlist-on-command-delete"
+              checked={deletePlaylist}
+              onChange={(e) => setDeletePlaylist(e.target.checked)}
+              className="mt-1 rounded border-input"
+            />
+            <Label
+              htmlFor="delete-playlist-on-command-delete"
+              className="cursor-pointer font-normal"
+            >
+              Also delete playlist from Plex/Jellyfin
+            </Label>
+          </div>
+        )}
+        <DialogFooter>
+          <Button variant="outline" onClick={() => handleOpenChange(false)} disabled={isDeleting}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            disabled={isDeleting}
+            onClick={() => void onConfirm(deletePlaylist)}
+          >
+            {isDeleting ? "Deleting…" : "Delete"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -110,8 +110,12 @@ class ApiClient {
     });
   }
 
-  async deleteCommand(commandName: string): Promise<{ message: string }> {
-    return await this.request(`/api/commands/${commandName}`, {
+  async deleteCommand(
+    commandName: string,
+    options?: { deletePlaylist?: boolean }
+  ): Promise<{ message: string }> {
+    const params = options?.deletePlaylist === true ? "?delete_playlist=true" : "";
+    return await this.request(`/api/commands/${commandName}${params}`, {
       method: "DELETE",
     });
   }

--- a/frontend/src/pages/Commands.tsx
+++ b/frontend/src/pages/Commands.tsx
@@ -42,6 +42,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { CreatePlaylistSyncDialog } from "@/components/CreatePlaylistSyncDialog";
+import { DeleteCommandDialog } from "@/components/DeleteCommandDialog";
 import { fromExpiresAtIso, toExpiresAtIso } from "@/lib/expiration";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
@@ -115,6 +116,8 @@ export function CommandsPage() {
   };
 
   const [showNewCommandDialog, setShowNewCommandDialog] = useState(false);
+  const [deleteCommandTarget, setDeleteCommandTarget] = useState<string | null>(null);
+  const [deleteCommandDeleting, setDeleteCommandDeleting] = useState(false);
   const [editingCommand, setEditingCommand] = useState<CommandConfig | null>(null);
   const [editForm, setEditForm] = useState<CommandEditFormState>({});
   const [plexAccounts, setPlexAccounts] = useState<{ id: string; name: string }[]>([]);
@@ -528,22 +531,24 @@ export function CommandsPage() {
     }
   };
 
-  const handleDelete = async (commandName: string) => {
+  const handleDelete = (commandName: string) => {
     if (BUILTIN_COMMANDS.includes(commandName)) return;
-    if (
-      !confirm(
-        `Are you sure you want to delete the command "${commandName}"? This cannot be undone.`
-      )
-    ) {
-      return;
-    }
+    setDeleteCommandTarget(commandName);
+  };
+
+  const confirmDeleteCommand = async (deletePlaylist: boolean) => {
+    if (!deleteCommandTarget) return;
+    setDeleteCommandDeleting(true);
     try {
-      await api.deleteCommand(commandName);
+      await api.deleteCommand(deleteCommandTarget, { deletePlaylist });
       toast.success("Command deleted");
+      setDeleteCommandTarget(null);
       loadCommands();
     } catch (error) {
       toast.error("Failed to delete command");
       console.error(error);
+    } finally {
+      setDeleteCommandDeleting(false);
     }
   };
 
@@ -1657,6 +1662,15 @@ export function CommandsPage() {
           )}
         </DialogContent>
       </Dialog>
+      <DeleteCommandDialog
+        open={deleteCommandTarget !== null}
+        commandName={deleteCommandTarget}
+        onOpenChange={(open) => {
+          if (!open) setDeleteCommandTarget(null);
+        }}
+        onConfirm={confirmDeleteCommand}
+        isDeleting={deleteCommandDeleting}
+      />
     </div>
   );
 }

--- a/services/command_cleanup.py
+++ b/services/command_cleanup.py
@@ -209,11 +209,14 @@ class CommandCleanupService:
         Only deletes playlist when expires_at_delete_playlist is True (default).
         """
         cfg = command_config.config_json or {}
-        name = command_config.command_name or ""
-        delete_playlist = cfg.get("expires_at_delete_playlist", True)
-
-        if not delete_playlist:
+        if not cfg.get("expires_at_delete_playlist", True):
             return
+        self.delete_playlist_for_command(command_config)
+
+    def delete_playlist_for_command(self, command_config: CommandConfig) -> None:
+        """Delete the target playlist associated with a command (if any)."""
+        cfg = command_config.config_json or {}
+        name = command_config.command_name or ""
 
         if name.startswith("playlist_sync_"):
             target = str(cfg.get("target", "plex")).lower()
@@ -249,7 +252,9 @@ class CommandCleanupService:
                     pl_title = f"[Cmdarr] Artist Essentials: {suffix}"
                 else:
                     pl_title = "[Cmdarr] Artist Essentials: Mix"
-            self._delete_playlist_if_exists(target, pl_title)
+            self._delete_playlist_if_exists(
+                target, pl_title, playlist_id=cfg.get("last_playlist_id")
+            )
         elif name.startswith("lfm_similar_"):
             target = str(cfg.get("target", "plex")).lower()
             pl_title = cfg.get("last_playlist_title")
@@ -268,7 +273,9 @@ class CommandCleanupService:
                     pl_title = f"[Cmdarr] Last.fm Similar: {suffix}"
                 else:
                     pl_title = "[Cmdarr] Last.fm Similar: Mix"
-            self._delete_playlist_if_exists(target, pl_title)
+            self._delete_playlist_if_exists(
+                target, pl_title, playlist_id=cfg.get("last_playlist_id")
+            )
         elif name.startswith("setlistfm_"):
             target = str(cfg.get("target", "plex")).lower()
             pl_title = cfg.get("last_playlist_title")
@@ -276,7 +283,9 @@ class CommandCleanupService:
                 from commands.playlist_generator_helpers import compute_setlistfm_playlist_title
 
                 pl_title = compute_setlistfm_playlist_title(dict(cfg))
-            self._delete_playlist_if_exists(target, pl_title)
+            self._delete_playlist_if_exists(
+                target, pl_title, playlist_id=cfg.get("last_playlist_id")
+            )
         elif name.startswith("daylist_"):
             token = self._get_user_token_for_playlist_delete(cfg)
             self._delete_playlist_if_exists("plex", "[Cmdarr] Daylist", token_override=token)
@@ -305,7 +314,9 @@ class CommandCleanupService:
                     pl_title = f"[Cmdarr] Mood: {_build_auto_playlist_suffix(moods)}"
                 else:
                     pl_title = "[Cmdarr] Mood: Mix"
-            self._delete_playlist_if_exists("plex", pl_title)
+            self._delete_playlist_if_exists(
+                "plex", pl_title, playlist_id=cfg.get("last_playlist_id")
+            )
         elif name.startswith("local_discovery_"):
             token = self._get_user_token_for_playlist_delete(cfg)
             self._delete_playlist_if_exists(
@@ -324,14 +335,24 @@ class CommandCleanupService:
                     token = self._get_user_token_for_playlist_delete(
                         {"plex_history_account_id": user_id}
                     )
-                    self._delete_playlist_if_exists(target, pl_title, token_override=token)
+                    self._delete_playlist_if_exists(
+                        target,
+                        pl_title,
+                        playlist_id=cfg.get("last_playlist_id"),
+                        token_override=token,
+                    )
             else:
                 token_override = None
                 if target == "plex":
                     token_override = self._get_user_token_for_playlist_delete(
                         {"plex_history_account_id": cfg.get("plex_playlist_account_id")}
                     )
-                self._delete_playlist_if_exists(target, pl_title, token_override=token_override)
+                self._delete_playlist_if_exists(
+                    target,
+                    pl_title,
+                    playlist_id=cfg.get("last_playlist_id"),
+                    token_override=token_override,
+                )
 
     def _get_user_token_for_playlist_delete(self, cfg: dict) -> str | None:
         """Resolve user token for daylist/local_discovery playlist deletion.
@@ -358,32 +379,41 @@ class CommandCleanupService:
             return None
 
     def _delete_playlist_if_exists(
-        self, target: str, playlist_name: str, token_override: str | None = None
+        self,
+        target: str,
+        playlist_name: str | None = None,
+        *,
+        playlist_id: str | None = None,
+        token_override: str | None = None,
     ):
-        """Delete playlist from Plex or Jellyfin if it exists."""
+        """Delete playlist from Plex or Jellyfin by ID (preferred) or name."""
         try:
             from commands.config_adapter import Config
+            from commands.playlist_generator_helpers import delete_playlist_on_target
 
             config = Config()
             if target == "plex":
                 from clients.client_plex import PlexClient
 
                 client = PlexClient(config, token_override=token_override)
-                pl = client.find_playlist_by_name(playlist_name)
-                if pl and pl.get("ratingKey"):
-                    client.delete_playlist(pl["ratingKey"])
-                    logger.info(f"Deleted expired playlist from Plex: {playlist_name}")
+                delete_playlist_on_target(
+                    client,
+                    playlist_id=playlist_id,
+                    playlist_title=playlist_name,
+                    logger=logger,
+                )
             elif target == "jellyfin":
                 from clients.client_jellyfin import JellyfinClient
 
                 client = JellyfinClient(config)
-                pl = client.find_playlist_by_name(playlist_name)
-                if pl and pl.get("Id"):
-                    if hasattr(client, "delete_playlist_sync"):
-                        client.delete_playlist_sync(pl["Id"])
-                        logger.info(f"Deleted expired playlist from Jellyfin: {playlist_name}")
+                delete_playlist_on_target(
+                    client,
+                    playlist_id=playlist_id,
+                    playlist_title=playlist_name,
+                    logger=logger,
+                )
         except Exception as e:
-            logger.warning(f"Could not delete playlist {playlist_name}: {e}")
+            logger.warning(f"Could not delete playlist: {e}")
 
     async def cleanup_startup_stuck_commands(self) -> list[str]:
         """

--- a/tests/test_playlist_identity_helpers.py
+++ b/tests/test_playlist_identity_helpers.py
@@ -1,0 +1,42 @@
+"""Tests for playlist identity helpers."""
+
+from unittest.mock import MagicMock, patch
+
+from commands.playlist_generator_helpers import (
+    delete_playlist_on_target,
+    persist_playlist_identity,
+)
+
+
+def test_persist_playlist_identity_writes_title_and_id():
+    mock_cmd = MagicMock()
+    mock_cmd.config_json = {}
+    mock_session = MagicMock()
+    mock_session.query.return_value.filter.return_value.first.return_value = mock_cmd
+
+    mock_db = MagicMock()
+    mock_db.get_config_session_sync.return_value = mock_session
+
+    with patch(
+        "database.database.get_database_manager",
+        return_value=mock_db,
+    ):
+        persist_playlist_identity(
+            "top_tracks_foo",
+            "top_tracks_",
+            "[Cmdarr] Artist Essentials: A · B",
+            "plex-123",
+            MagicMock(),
+        )
+
+    assert mock_cmd.config_json["last_playlist_title"] == "[Cmdarr] Artist Essentials: A · B"
+    assert mock_cmd.config_json["last_playlist_id"] == "plex-123"
+    mock_session.commit.assert_called_once()
+
+
+def test_delete_playlist_on_target_prefers_id():
+    client = MagicMock()
+    client.get_playlist_by_id.return_value = {"ratingKey": "rk1"}
+    delete_playlist_on_target(client, playlist_id="rk1", playlist_title="Old Title")
+    client.delete_playlist.assert_called_once_with("rk1")
+    client.find_playlist_by_name.assert_not_called()


### PR DESCRIPTION
Store last_playlist_id alongside last_playlist_title, prefer ID for sync/update and cleanup, and let users optionally remove the target playlist when deleting a command via DeleteCommandDialog.