### PR TITLE
Fix TM artist matching on multi-artist bills and document provider av…

### DIFF
--- a/app/api/events.py
+++ b/app/api/events.py
@@ -72,18 +72,31 @@ class FestivalHiddenRequest(BaseModel):
 @router.get("/provider-status")
 async def provider_status():
     """Which providers are enabled and configured."""
+    from utils.artist_events_providers import provider_status_payload
+
     bit = config_service.get("ARTIST_EVENTS_BANDSINTOWN_ENABLED", False)
     bit_app = (config_service.get("ARTIST_EVENTS_BANDSINTOWN_APP_ID", "") or "").strip()
     sk = config_service.get("ARTIST_EVENTS_SONGKICK_ENABLED", False)
     sk_key = (config_service.get("ARTIST_EVENTS_SONGKICK_API_KEY", "") or "").strip()
     tm = config_service.get("ARTIST_EVENTS_TICKETMASTER_ENABLED", False)
     tm_key = (config_service.get("ARTIST_EVENTS_TICKETMASTER_API_KEY", "") or "").strip()
+    bandsintown = provider_status_payload(
+        enabled=bool(bit and bit_app), configured=bool(bit_app), provider_id="bandsintown"
+    )
+    songkick = provider_status_payload(
+        enabled=bool(sk and sk_key), configured=bool(sk_key), provider_id="songkick"
+    )
+    ticketmaster = provider_status_payload(
+        enabled=bool(tm and tm_key), configured=bool(tm_key), provider_id="ticketmaster"
+    )
+    any_ready = bandsintown["enabled"] or songkick["enabled"] or ticketmaster["enabled"]
     return {
         "success": True,
-        "bandsintown": {"enabled": bool(bit and bit_app), "configured": bool(bit_app)},
-        "songkick": {"enabled": bool(sk and sk_key), "configured": bool(sk_key)},
-        "ticketmaster": {"enabled": bool(tm and tm_key), "configured": bool(tm_key)},
-        "any_ready": bool((bit and bit_app) or (sk and sk_key) or (tm and tm_key)),
+        "bandsintown": bandsintown,
+        "songkick": songkick,
+        "ticketmaster": ticketmaster,
+        "any_ready": any_ready,
+        "recommended_provider": "ticketmaster",
     }
 
 

--- a/clients/client_ticketmaster.py
+++ b/clients/client_ticketmaster.py
@@ -83,38 +83,40 @@ class TicketmasterClient(BaseAPIClient):
         """
         Decide whether a TM keyword-search event genuinely features this artist.
 
-        Prefer MBID match via `_embedded.attractions[*].externalLinks.musicbrainz[*].id`.
-        If TM provides MBIDs for any attraction on the event and none match our MBID, the
-        event is rejected outright — this kills the "substring of artist name matches some
-        unrelated short attraction title" false positives we were seeing.
-
-        Fall back to whole-phrase, token-aligned match of the artist name inside an
-        attraction name (or the event title if the event has no attractions at all).
+        Matching is per attraction on multi-artist bills:
+        - If an attraction name matches the artist (whole-phrase token match), accept when
+          that attraction has no MusicBrainz ID or its MBID matches Lidarr.
+          Reject only when that same attraction has a conflicting TM MBID.
+        - Co-headliner MBIDs do not veto an opener/support act matched by name.
+        - If no attraction name matches, accept when any attraction MBID matches Lidarr.
+        - If the event has no attractions, fall back to the event title phrase match.
         """
         artist_tokens = _tokens(artist_name)
         if not artist_tokens:
             return False
         emb = ev.get("_embedded") or {}
         attractions = emb.get("attractions") or []
-
-        if artist_mbid:
-            mb_target = artist_mbid.lower().strip()
-            any_mbid_seen = False
-            for att in attractions:
-                mbs = (att.get("externalLinks") or {}).get("musicbrainz") or []
-                for mb in mbs:
-                    mid = (mb.get("id") or "").lower().strip()
-                    if not mid:
-                        continue
-                    any_mbid_seen = True
-                    if mid == mb_target:
-                        return True
-            if any_mbid_seen:
-                return False
+        mb_target = artist_mbid.lower().strip() if artist_mbid else ""
 
         for att in attractions:
-            if _contains_phrase(_tokens(att.get("name") or ""), artist_tokens):
-                return True
+            att_name = att.get("name") or ""
+            if not _contains_phrase(_tokens(att_name), artist_tokens):
+                continue
+            att_mbids: list[str] = []
+            for mb in (att.get("externalLinks") or {}).get("musicbrainz") or []:
+                mid = (mb.get("id") or "").strip().lower()
+                if mid:
+                    att_mbids.append(mid)
+            if mb_target and att_mbids:
+                return mb_target in att_mbids
+            return True
+
+        if mb_target:
+            for att in attractions:
+                for mb in (att.get("externalLinks") or {}).get("musicbrainz") or []:
+                    mid = (mb.get("id") or "").strip().lower()
+                    if mid and mid == mb_target:
+                        return True
 
         if not attractions:
             return _contains_phrase(_tokens(ev.get("name") or ""), artist_tokens)

--- a/docs/artist-events-providers.md
+++ b/docs/artist-events-providers.md
@@ -1,0 +1,33 @@
+# Artist event providers
+
+Cmdarr aggregates upcoming shows from optional external APIs. **Ticketmaster Discovery** is the only source with reliable self-serve API access for new deployments.
+
+## Ticketmaster Discovery (recommended)
+
+- **Registration:** Open — [developer.ticketmaster.com](https://developer.ticketmaster.com/)
+- **Auth:** `apikey` query param (Consumer Key from the developer portal)
+- **Coverage:** US music events; keyword search + attraction metadata
+- **Cmdarr notes:** Multi-artist bills match per attraction (name phrase + optional MusicBrainz ID on that attraction only). Co-headliner MBIDs do not block openers.
+
+## Songkick (legacy / partner-only)
+
+- **Registration:** Closed for new hobbyist/student keys; [Songkick states](https://www.songkick.com/api_key_requests/new) they are not processing new applications while improving the API.
+- **Commercial use:** Requires partnership agreement and license fee ([inquiry form](https://support.songkick.com/hc/en-us/requests/new?ticket_form_id=360000526113)).
+- **Cmdarr:** Client remains for deployments with an existing key. Not recommended for new setups.
+
+## Bandsintown (legacy / partner-only)
+
+- **Registration:** [Partner approval required](https://corp.bandsintown.com/data-applications-terms); intended for artists/enterprises, not general third-party apps.
+- **Public `app_id`:** Historically any string worked for the REST API; newer access is restricted and may return 403 without partner approval.
+- **Cmdarr:** Client remains for deployments with a working `app_id`. Not recommended for new setups.
+
+## Alternatives considered (not implemented)
+
+| Option | Notes |
+|--------|--------|
+| **SeatGeek API** | Partner/commercial; similar barriers to Songkick |
+| **AXS / Eventbrite** | Limited or partner-gated event APIs |
+| **Web scraping** | Fragile, ToS risk, high maintenance; avoided for now |
+| **Setlist.fm** | Set lists, not upcoming ticketed shows |
+
+If Songkick and Bandsintown are removed in a future release, existing `concert_event_source` rows for those providers would remain historical only; new ingests would be Ticketmaster-only.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,5 +1,6 @@
 import type {
   ArtistEventsStats,
+  EventsProviderInfo,
   CommandConfig,
   CommandExecution,
   CommandUpdateRequest,
@@ -415,10 +416,11 @@ class ApiClient {
   // Artist events (live shows, festivals, etc.)
   async getEventsProviderStatus(): Promise<{
     success: boolean;
-    bandsintown: { enabled: boolean; configured: boolean };
-    songkick: { enabled: boolean; configured: boolean };
-    ticketmaster: { enabled: boolean; configured: boolean };
+    bandsintown: EventsProviderInfo;
+    songkick: EventsProviderInfo;
+    ticketmaster: EventsProviderInfo;
     any_ready: boolean;
+    recommended_provider?: string;
   }> {
     return this.request("/api/events/provider-status");
   }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -111,6 +111,15 @@ export interface ArtistEventsStats {
   hidden_events: number;
 }
 
+export interface EventsProviderInfo {
+  enabled: boolean;
+  configured: boolean;
+  registration_open: boolean;
+  status: "available" | "partner_only" | string;
+  status_message: string;
+  docs_url?: string;
+}
+
 export interface StatusInfo {
   app_name: string;
   version: string;

--- a/frontend/src/pages/Events.tsx
+++ b/frontend/src/pages/Events.tsx
@@ -480,7 +480,11 @@ export function EventsPage() {
                   onCheckedChange={(c) => toggleProvider("ARTIST_EVENTS_BANDSINTOWN_ENABLED", c)}
                 />
                 <span className="text-[10px] text-muted-foreground whitespace-nowrap">
-                  {providerStatus?.bandsintown.enabled ? "ready" : "needs app ID"}
+                  {providerStatus?.bandsintown.enabled
+                    ? "ready"
+                    : providerStatus?.bandsintown.registration_open
+                      ? "needs app ID"
+                      : "partner only"}
                 </span>
               </div>
             </div>
@@ -492,7 +496,11 @@ export function EventsPage() {
                   onCheckedChange={(c) => toggleProvider("ARTIST_EVENTS_SONGKICK_ENABLED", c)}
                 />
                 <span className="text-[10px] text-muted-foreground whitespace-nowrap">
-                  {providerStatus?.songkick.enabled ? "ready" : "needs key"}
+                  {providerStatus?.songkick.enabled
+                    ? "ready"
+                    : providerStatus?.songkick.registration_open
+                      ? "needs key"
+                      : "partner only"}
                 </span>
               </div>
             </div>
@@ -509,6 +517,15 @@ export function EventsPage() {
               </div>
             </div>
           </div>
+          {providerStatus &&
+            (!providerStatus.bandsintown.registration_open ||
+              !providerStatus.songkick.registration_open) && (
+              <p className="text-xs text-muted-foreground leading-snug">
+                Songkick and Bandsintown are partner-only (no new public API keys). Ticketmaster is
+                the recommended source for new setups. Details:{" "}
+                <code className="text-[10px]">docs/artist-events-providers.md</code>
+              </p>
+            )}
           <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
             <div className="inline-flex">
               <Button

--- a/readme-extended.md
+++ b/readme-extended.md
@@ -208,7 +208,7 @@ With Library Cache:    1 library fetch + instant memory searches = ~30 seconds
 
 ### Event Sources (artist events)
 
-Upcoming shows are aggregated on **Artist events** (`/events`) from optional **Bandsintown**, **Songkick**, and **Ticketmaster Discovery**.
+Upcoming shows are aggregated on **Artist events** (`/events`) from optional **Ticketmaster Discovery** (recommended), plus legacy **Bandsintown** and **Songkick** support for deployments with existing partner keys. See `docs/artist-events-providers.md` for provider availability.
 
 **Where to configure what**
 
@@ -224,9 +224,9 @@ Data is refreshed by the **`artist_events_refresh`** command (scheduler, **Run s
 | Setting | Required? | Notes |
 |---------|-----------|--------|
 | `ARTIST_EVENTS_BANDSINTOWN_ENABLED` | No | Default off. Toggled on **Artist events**; omitted from Config UI to avoid duplication (still settable via env/DB). |
-| `ARTIST_EVENTS_BANDSINTOWN_APP_ID` | **Yes if Bandsintown enabled** | Bandsintown’s public API **`app_id`** query parameter: any stable string you choose (e.g. `cmdarr`). **Not** the HTTP User-Agent (see below). |
-| `ARTIST_EVENTS_SONGKICK_ENABLED` | No | Default off. Toggled on **Artist events** only. |
-| `ARTIST_EVENTS_SONGKICK_API_KEY` | **Yes if Songkick enabled** | Commercial/partnership keys are common; availability varies. |
+| `ARTIST_EVENTS_BANDSINTOWN_APP_ID` | **Legacy only** | Partner-issued `app_id`; new self-serve access is not available. |
+| `ARTIST_EVENTS_SONGKICK_ENABLED` | No | Default off. Legacy only — see provider doc. |
+| `ARTIST_EVENTS_SONGKICK_API_KEY` | **Legacy only** | Songkick is not issuing new API keys; paid partnership required for new access. |
 | `ARTIST_EVENTS_TICKETMASTER_ENABLED` | No | Default off. Toggled on **Artist events** only. |
 | `ARTIST_EVENTS_TICKETMASTER_API_KEY` | **Yes if Ticketmaster enabled** | [Ticketmaster Discovery API](https://developer.ticketmaster.com/products-and-docs/apis/getting-started/) uses a single `apikey` query parameter. Paste your **Consumer Key** here. The **Consumer Secret** is for other OAuth-style flows and is **not** used by Cmdarr’s Discovery GET requests. |
 | `ARTIST_EVENTS_USER_LAT` / `LON` / `USER_LABEL` | **No** | Distance filter only; set from **Artist events**. Hidden on Config. |

--- a/services/config_service.py
+++ b/services/config_service.py
@@ -567,7 +567,7 @@ class ConfigService:
                 "default_value": "",
                 "data_type": "string",
                 "category": "artist_events",
-                "description": "Bandsintown Public API app_id (required when enabled)",
+                "description": "Bandsintown app_id (partner approval required for new access; legacy only)",
             },
             {
                 "key": "ARTIST_EVENTS_SONGKICK_ENABLED",
@@ -582,7 +582,7 @@ class ConfigService:
                 "default_value": "",
                 "data_type": "string",
                 "category": "artist_events",
-                "description": "Songkick API key (required when enabled)",
+                "description": "Songkick API key (new keys not issued; paid partnership required; legacy only)",
                 "is_sensitive": True,
             },
             {

--- a/tests/test_client_matchers.py
+++ b/tests/test_client_matchers.py
@@ -1,12 +1,15 @@
 """Unit tests for the TicketmasterClient._event_matches_artist heuristic.
 
-These exercise the MBID-first rejection logic and the whole-phrase, token-aligned
-name fallback, which together should block the category of false positives we saw
-after 0.3.14-dev (e.g. TM returning an unrelated event whose attraction name was a
-substring of 'Pop Evil' or contained the word 'Unprocessed' for unrelated reasons).
+Per-attraction matching: MBID is authoritative only on the attraction whose name matches
+the artist; co-headliner MBIDs must not block openers. Whole-phrase name fallback when
+TM omits MusicBrainz links.
 """
 
 from clients.client_ticketmaster import TicketmasterClient
+
+AUTUMN_KINGS_MBID = "941109b5-51c5-4f4f-9d15-b8ae3ceb98bc"
+BVB_MBID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+ARCHERS_MBID = "bbbbbbbb-cccc-dddd-eeee-ffffffffffff"
 
 
 def _match(ev, name, mbid=""):
@@ -115,3 +118,75 @@ def test_multi_word_artist_name_must_match_as_contiguous_phrase():
         "_embedded": {"attractions": [{"name": "Pop and Evil Cover Band"}]},
     }
     assert _match(ev, "Pop Evil") is False
+
+
+def test_coheadliner_mbids_do_not_block_opener_name_match():
+    """Openers on a bill must match by attraction name when their attraction has no MBID."""
+    ev = {
+        "name": "Black Veil Brides: Vindicatour US 2026",
+        "_embedded": {
+            "attractions": [
+                {
+                    "name": "Black Veil Brides",
+                    "externalLinks": {"musicbrainz": [{"id": BVB_MBID}]},
+                },
+                {
+                    "name": "Archers",
+                    "externalLinks": {"musicbrainz": [{"id": ARCHERS_MBID}]},
+                },
+                {"name": "Autumn Kings"},
+            ]
+        },
+    }
+    assert _match(ev, "Autumn Kings", AUTUMN_KINGS_MBID) is True
+
+
+def test_coheadliner_mbids_accept_opener_with_matching_mbid_on_its_attraction():
+    ev = {
+        "name": "Black Veil Brides: Vindicatour US 2026",
+        "_embedded": {
+            "attractions": [
+                {
+                    "name": "Black Veil Brides",
+                    "externalLinks": {"musicbrainz": [{"id": BVB_MBID}]},
+                },
+                {
+                    "name": "Autumn Kings",
+                    "externalLinks": {"musicbrainz": [{"id": AUTUMN_KINGS_MBID}]},
+                },
+            ]
+        },
+    }
+    assert _match(ev, "Autumn Kings", AUTUMN_KINGS_MBID) is True
+
+
+def test_wrong_mbid_on_name_matched_attraction_rejects():
+    ev = {
+        "name": "Black Veil Brides: Vindicatour US 2026",
+        "_embedded": {
+            "attractions": [
+                {
+                    "name": "Autumn Kings",
+                    "externalLinks": {
+                        "musicbrainz": [{"id": "deadbeef-0000-0000-0000-000000000000"}]
+                    },
+                },
+            ]
+        },
+    }
+    assert _match(ev, "Autumn Kings", AUTUMN_KINGS_MBID) is False
+
+
+def test_global_mbid_match_without_name_phrase_on_attraction():
+    ev = {
+        "name": "Some Festival",
+        "_embedded": {
+            "attractions": [
+                {
+                    "name": "The Band TM Calls Them",
+                    "externalLinks": {"musicbrainz": [{"id": AUTUMN_KINGS_MBID}]},
+                },
+            ]
+        },
+    }
+    assert _match(ev, "Autumn Kings", AUTUMN_KINGS_MBID) is True

--- a/utils/artist_events_providers.py
+++ b/utils/artist_events_providers.py
@@ -1,0 +1,53 @@
+"""Artist event source availability metadata (for API/UI; not enforcement)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Ticketmaster Discovery is the only source with open self-serve API registration today.
+# Bandsintown and Songkick remain in Cmdarr for deployments with existing partner keys.
+PROVIDER_CATALOG: dict[str, dict[str, Any]] = {
+    "ticketmaster": {
+        "label": "Ticketmaster",
+        "registration_open": True,
+        "status": "available",
+        "status_message": (
+            "Ticketmaster Discovery API: free developer key (Consumer Key) at "
+            "developer.ticketmaster.com. Cmdarr's primary supported source."
+        ),
+        "docs_url": "https://developer.ticketmaster.com/products-and-docs/apis/getting-started/",
+    },
+    "bandsintown": {
+        "label": "Bandsintown",
+        "registration_open": False,
+        "status": "partner_only",
+        "status_message": (
+            "Bandsintown requires a partner-issued app_id and written approval; not available "
+            "for new self-serve integrations. Legacy keys may still work. See "
+            "docs/artist-events-providers.md."
+        ),
+        "docs_url": "https://help.artists.bandsintown.com/en/articles/7053475-what-is-the-bandsintown-api",
+    },
+    "songkick": {
+        "label": "Songkick",
+        "registration_open": False,
+        "status": "partner_only",
+        "status_message": (
+            "Songkick is not issuing new API keys; commercial use requires a paid partnership. "
+            "Legacy keys may still work. See docs/artist-events-providers.md."
+        ),
+        "docs_url": "https://www.songkick.com/developer",
+    },
+}
+
+
+def provider_status_payload(*, enabled: bool, configured: bool, provider_id: str) -> dict[str, Any]:
+    meta = PROVIDER_CATALOG[provider_id]
+    return {
+        "enabled": enabled,
+        "configured": configured,
+        "registration_open": meta["registration_open"],
+        "status": meta["status"],
+        "status_message": meta["status_message"],
+        "docs_url": meta["docs_url"],
+    }


### PR DESCRIPTION
…ailability.

Per-attraction MBID/name matching stops co-headliner IDs from vetoing openers, adds regression tests, and surfaces partner-only status for Songkick/Bandsintown in API and UI.