### PR TITLE
Fix multi-arch Docker build by compiling frontend on BUILDPLATFORM.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Stage 1: Build React frontend
-FROM node:24-trixie-slim@sha256:4f2b45e32dc7d2caf66b6dbd59fac50e32f8077769efe0ef4d4c3f114672537d AS frontend-builder
+# Stage 1: Build React frontend (always on build host — static assets, no per-arch compile)
+FROM --platform=$BUILDPLATFORM node:24-trixie-slim@sha256:4f2b45e32dc7d2caf66b6dbd59fac50e32f8077769efe0ef4d4c3f114672537d AS frontend-builder
 WORKDIR /app/frontend
 COPY frontend/package*.json ./
 RUN npm ci


### PR DESCRIPTION
The React build is static output and does not need QEMU arm64 emulation during npm run build, which was failing intermittently on the develop image publish job.