### PR TITLE
Consolidate artist-events dedupe key logic into event_geo.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 - **Playlist identity**: Plex/Jellyfin playlists are now tracked by stored ID as well as title, so overlapping names no longer collide; command delete now offers ability to also delete the playlist in Plex/Jellyfin via optional checkbox.
-- **Artist Events providers**: Removed Bandsintown and Songkick; added **SeatGeek** (open API) and **Deezer** (unofficial GraphQL via ARL) as secondary/tertiary event sources alongside Ticketmaster. Events page shows per-provider badges and source filters; deduped shows keep links for each provider that matched.
+- **Artist Events providers**: Removed Bandsintown and Songkick; added **SeatGeek** (developer API; requires `client_id`) and **Deezer** (unofficial GraphQL via ARL) as secondary/tertiary event sources alongside Ticketmaster. Events page shows per-provider badges and source filters; deduped shows keep links for each provider that matched.
 
 ### Fixes
 - **Artist Events — Ticketmaster matching**: Multi-artist bills no longer reject a show when a co-headliner’s MusicBrainz ID differs from the library artist; matching uses per-attraction MBID/name checks so openers and co-bills resolve correctly.
 
 ### Housekeeping
 - **Security & CI**: Frontend bumps for vite and react-router; `.trivyignore` updates for new CVEs without fix, cleanup of other items that have been fixed.
-- **UI & maintainability**: Command edit/create forms aligned (expiry saves, defaults, section order); shared confirm/edit components, `make check` TypeScript typecheck, and save-time Artist Essentials / Setlist titles matched to library-validated artists.
+- **UI & maintainability**: Command edit/create forms aligned (expiry saves, defaults, section order); shared confirm/edit components, `make check` TypeScript typecheck, and save-time Artist Essentials / Setlist titles matched to library-validated artists; artist-events dedupe, place parsing, and venue geocoding consolidated into shared utils (`event_geo`, `event_dedupe_coalesce`, `venue_geocode`).
 - **Schema migration ledger**: Database migrations are tracked per name in a `schema_migration` ledger and run on every startup when pending (not only when the app version changes). Existing installs backfill the ledger from schema checks. Early alpha: jumping between 0.x minors may still require a fresh install; this lays groundwork for reliable upgrades at 1.x.
 
 ## [0.3.15] - 2026-05-26

--- a/tests/test_event_geo.py
+++ b/tests/test_event_geo.py
@@ -2,6 +2,7 @@
 
 from utils.event_geo import (
     coerce_location_str,
+    compute_event_dedupe_key,
     haversine_miles,
     lat_lon_deg_bounds_for_radius_miles,
     make_dedupe_key,
@@ -10,6 +11,7 @@ from utils.event_geo import (
     parse_float,
     parse_place_city_region,
     venue_fingerprint,
+    venue_fingerprint_legacy,
 )
 
 
@@ -27,6 +29,29 @@ def test_dedupe_key_stable():
     k2 = make_dedupe_key("mbid-1", "2026-06-01", fp)
     assert k1 == k2
     assert k1 != make_dedupe_key("mbid-2", "2026-06-01", fp)
+
+
+def test_compute_event_dedupe_key_matches_manual():
+    fp = venue_fingerprint("The Fillmore", "San Francisco", "CA", 37.7845, -122.4324)
+    manual = make_dedupe_key("mbid-1", "2026-06-01", fp)
+    assert (
+        compute_event_dedupe_key(
+            "mbid-1",
+            "2026-06-01",
+            "The Fillmore",
+            "San Francisco",
+            "CA",
+            37.7845,
+            -122.4324,
+        )
+        == manual
+    )
+
+
+def test_venue_fingerprint_legacy_differs_when_region_present():
+    new_fp = venue_fingerprint("Brooklyn Bowl", "Nashville", "TN", 36.16, -86.77)
+    old_fp = venue_fingerprint_legacy("Brooklyn Bowl", "Nashville", "TN", 36.16, -86.77)
+    assert new_fp != old_fp
 
 
 def test_coerce_location_str_nested_region():

--- a/tools/diagnose_event_dedupe.py
+++ b/tools/diagnose_event_dedupe.py
@@ -15,7 +15,6 @@ From inside the Cmdarr container (repo mounted or copied):
 from __future__ import annotations
 
 import argparse
-import hashlib
 import sqlite3
 import sys
 from collections import defaultdict
@@ -24,56 +23,7 @@ from pathlib import Path
 # Allow imports from repo root when run as `python tools/diagnose_event_dedupe.py`
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from utils.event_geo import (  # noqa: E402
-    coerce_location_str,
-    make_dedupe_key,
-    normalize_city_name,
-    normalize_venue_name,
-    venue_fingerprint,
-)
-
-
-def _venue_fingerprint_old(
-    venue_name: str | None,
-    city: str | None,
-    region: str | None,
-    lat: float | None,
-    lon: float | None,
-) -> str:
-    """Pre-fix fingerprint: region included when venue name is present."""
-    c_norm = normalize_city_name(coerce_location_str(city))
-    r_norm = (coerce_location_str(region) or "").strip().lower()
-    vn = normalize_venue_name(coerce_location_str(venue_name), c_norm)
-    if vn:
-        raw = f"v|{vn}|{c_norm}|{r_norm}"
-    else:
-        if lat is not None and lon is not None:
-            geo = f"{round(lat, 1)},{round(lon, 1)}"
-        else:
-            geo = ""
-        raw = f"g|{c_norm}|{r_norm}|{geo}"
-    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:24]
-
-
-def _dedupe_key(
-    artist_mbid: str,
-    local_date: str,
-    venue_name,
-    venue_city,
-    venue_region,
-    venue_lat,
-    venue_lon,
-    *,
-    use_old: bool,
-) -> str:
-    v_name = coerce_location_str(venue_name)
-    v_city = coerce_location_str(venue_city)
-    v_region = coerce_location_str(venue_region)
-    if use_old:
-        fp = _venue_fingerprint_old(v_name, v_city, v_region, venue_lat, venue_lon)
-    else:
-        fp = venue_fingerprint(v_name, v_city, v_region, venue_lat, venue_lon)
-    return make_dedupe_key(artist_mbid, local_date, fp)
+from utils.event_geo import compute_event_dedupe_key  # noqa: E402
 
 
 def _load_events(conn: sqlite3.Connection) -> list[dict]:
@@ -135,7 +85,7 @@ def analyze(events: list[dict]) -> dict:
             continue
         for tm in tm_rows:
             for dz in dz_rows:
-                old_tm = _dedupe_key(
+                old_tm = compute_event_dedupe_key(
                     tm["artist_mbid"],
                     tm["local_date"],
                     tm["venue_name"],
@@ -143,9 +93,9 @@ def analyze(events: list[dict]) -> dict:
                     tm["venue_region"],
                     tm["venue_lat"],
                     tm["venue_lon"],
-                    use_old=True,
+                    legacy_fingerprint=True,
                 )
-                old_dz = _dedupe_key(
+                old_dz = compute_event_dedupe_key(
                     dz["artist_mbid"],
                     dz["local_date"],
                     dz["venue_name"],
@@ -153,9 +103,9 @@ def analyze(events: list[dict]) -> dict:
                     dz["venue_region"],
                     dz["venue_lat"],
                     dz["venue_lon"],
-                    use_old=True,
+                    legacy_fingerprint=True,
                 )
-                new_tm = _dedupe_key(
+                new_tm = compute_event_dedupe_key(
                     tm["artist_mbid"],
                     tm["local_date"],
                     tm["venue_name"],
@@ -163,9 +113,8 @@ def analyze(events: list[dict]) -> dict:
                     tm["venue_region"],
                     tm["venue_lat"],
                     tm["venue_lon"],
-                    use_old=False,
                 )
-                new_dz = _dedupe_key(
+                new_dz = compute_event_dedupe_key(
                     dz["artist_mbid"],
                     dz["local_date"],
                     dz["venue_name"],
@@ -173,7 +122,6 @@ def analyze(events: list[dict]) -> dict:
                     dz["venue_region"],
                     dz["venue_lat"],
                     dz["venue_lon"],
-                    use_old=False,
                 )
                 if old_tm != old_dz and new_tm == new_dz:
                     split_pairs.append(
@@ -197,7 +145,7 @@ def analyze(events: list[dict]) -> dict:
 
     new_groups: dict[str, list[int]] = defaultdict(list)
     for ev in events:
-        nk = _dedupe_key(
+        nk = compute_event_dedupe_key(
             ev["artist_mbid"],
             ev["local_date"],
             ev["venue_name"],
@@ -205,7 +153,6 @@ def analyze(events: list[dict]) -> dict:
             ev["venue_region"],
             ev["venue_lat"],
             ev["venue_lon"],
-            use_old=False,
         )
         new_groups[nk].append(ev["id"])
 

--- a/utils/event_dedupe_coalesce.py
+++ b/utils/event_dedupe_coalesce.py
@@ -5,12 +5,7 @@ from __future__ import annotations
 import sqlite3
 from collections import defaultdict
 
-from utils.event_geo import (
-    coerce_location_str,
-    make_dedupe_key,
-    parse_place_city_region,
-    venue_fingerprint,
-)
+from utils.event_geo import compute_event_dedupe_key, parse_place_city_region
 
 
 def _row_coords(lat, lon) -> bool:
@@ -40,21 +35,6 @@ def coalesce_concert_event_duplicates(cursor: sqlite3.Cursor) -> None:
 
     by_id: dict[int, tuple] = {row[0]: row for row in rows}
 
-    def compute_dedupe_key(
-        artist_mbid: str,
-        local_date: str,
-        venue_name,
-        venue_city,
-        venue_region,
-        venue_lat,
-        venue_lon,
-    ) -> str:
-        v_name = coerce_location_str(venue_name)
-        v_city = coerce_location_str(venue_city)
-        v_region = coerce_location_str(venue_region)
-        fp = venue_fingerprint(v_name, v_city, v_region, venue_lat, venue_lon)
-        return make_dedupe_key(artist_mbid, local_date, fp)
-
     def winner_sort_key(event_id: int) -> tuple:
         row = by_id[event_id]
         _id, _mbid, _an, vn, vc, vr, vlat, vlon, _ld, _ui = row
@@ -65,7 +45,7 @@ def coalesce_concert_event_duplicates(cursor: sqlite3.Cursor) -> None:
     groups: dict[str, list[int]] = defaultdict(list)
     for row in rows:
         _id, artist_mbid, _an, vn, vc, vr, vlat, vlon, local_date, _ui = row
-        dk = compute_dedupe_key(artist_mbid, local_date, vn, vc, vr, vlat, vlon)
+        dk = compute_event_dedupe_key(artist_mbid, local_date, vn, vc, vr, vlat, vlon)
         groups[dk].append(_id)
 
     for _dk, ids in groups.items():
@@ -182,7 +162,7 @@ def coalesce_concert_event_duplicates(cursor: sqlite3.Cursor) -> None:
     )
     for row in cursor.fetchall():
         eid, artist_mbid, vn, vc, vr, vlat, vlon, local_date = row
-        new_dk = compute_dedupe_key(artist_mbid, local_date, vn, vc, vr, vlat, vlon)
+        new_dk = compute_event_dedupe_key(artist_mbid, local_date, vn, vc, vr, vlat, vlon)
         cursor.execute(
             "UPDATE concert_event SET dedupe_key = ? WHERE id = ?",
             (new_dk, eid),

--- a/utils/event_geo.py
+++ b/utils/event_geo.py
@@ -112,6 +112,28 @@ def normalize_venue_name(name: str | None, city: str | None = None) -> str:
     return s
 
 
+def venue_fingerprint_legacy(
+    venue_name: str | None,
+    city: str | None,
+    region: str | None,
+    lat: float | None,
+    lon: float | None,
+) -> str:
+    """Pre-0.3.16 fingerprint: region included when a venue name is present."""
+    c_norm = normalize_city_name(coerce_location_str(city))
+    r_norm = (coerce_location_str(region) or "").strip().lower()
+    vn = normalize_venue_name(coerce_location_str(venue_name), c_norm)
+    if vn:
+        raw = f"v|{vn}|{c_norm}|{r_norm}"
+    else:
+        if lat is not None and lon is not None:
+            geo = f"{round(lat, 1)},{round(lon, 1)}"
+        else:
+            geo = ""
+        raw = f"g|{c_norm}|{r_norm}|{geo}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:24]
+
+
 def venue_fingerprint(
     venue_name: str | None,
     city: str | None,
@@ -152,6 +174,28 @@ def venue_fingerprint(
 def make_dedupe_key(artist_mbid: str, local_date: str, fp: str) -> str:
     raw = f"{artist_mbid}|{local_date}|{fp}"
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def compute_event_dedupe_key(
+    artist_mbid: str,
+    local_date: str,
+    venue_name: Any,
+    venue_city: Any,
+    venue_region: Any,
+    venue_lat: float | None,
+    venue_lon: float | None,
+    *,
+    legacy_fingerprint: bool = False,
+) -> str:
+    """Canonical dedupe key for a concert row from venue/place fields."""
+    v_name = coerce_location_str(venue_name)
+    v_city = coerce_location_str(venue_city)
+    v_region = coerce_location_str(venue_region)
+    if legacy_fingerprint:
+        fp = venue_fingerprint_legacy(v_name, v_city, v_region, venue_lat, venue_lon)
+    else:
+        fp = venue_fingerprint(v_name, v_city, v_region, venue_lat, venue_lon)
+    return make_dedupe_key(artist_mbid, local_date, fp)
 
 
 def parse_float(val: Any) -> float | None:

--- a/utils/event_ingest.py
+++ b/utils/event_ingest.py
@@ -7,7 +7,7 @@ from typing import Any
 from sqlalchemy.orm import Session
 
 from database.config_models import ArtistEvent, ArtistEventSource
-from utils.event_geo import coerce_location_str, make_dedupe_key, venue_fingerprint
+from utils.event_geo import coerce_location_str, compute_event_dedupe_key
 from utils.tm_event_meta import merge_event_kind
 
 
@@ -22,14 +22,15 @@ def persist_normalized_events(session: Session, items: list[dict[str, Any]]) -> 
         v_city = coerce_location_str(item.get("venue_city"))
         v_region = coerce_location_str(item.get("venue_region"))
         v_country = coerce_location_str(item.get("venue_country"))
-        fp = venue_fingerprint(
+        dk = compute_event_dedupe_key(
+            item["artist_mbid"],
+            item["local_date"],
             v_name,
             v_city,
             v_region,
             item.get("venue_lat"),
             item.get("venue_lon"),
         )
-        dk = make_dedupe_key(item["artist_mbid"], item["local_date"], fp)
         existing = session.query(ArtistEvent).filter(ArtistEvent.dedupe_key == dk).first()
         if not existing:
             ek = (item.get("event_kind") or "show").strip() or "show"


### PR DESCRIPTION
Share compute_event_dedupe_key and venue_fingerprint_legacy across ingest, coalesce, and the diagnostic tool; extend CHANGELOG housekeeping and correct SeatGeek API wording.