### PR TITLE
Add don't-track artists and release date filter for New Releases.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Features
 - **Playlist identity**: Plex/Jellyfin playlists are now tracked by stored ID as well as title, so overlapping names no longer collide; command delete now offers ability to also delete the playlist in Plex/Jellyfin via optional checkbox.
 - **Artist Events providers**: Removed Bandsintown and Songkick; added **SeatGeek** (developer API; requires `client_id`) and **Deezer** (unofficial GraphQL via ARL) as secondary/tertiary event sources alongside Ticketmaster. Events page shows per-provider badges and source filters; deduped shows keep links for each provider that matched.
+- **New Releases Discovery**: **Don't track artist** list (like Artist Events hides) skips artists on future scans and clears their pending rows; pending list supports a **release date** filter (30/60/90/180 days or this year) to focus on genuinely recent releases.
 
 ### Fixes
 - **Artist Events — Ticketmaster matching**: Multi-artist bills no longer reject a show when a co-headliner’s MusicBrainz ID differs from the library artist; matching uses per-attraction MBID/name checks so openers and co-bills resolve correctly.

--- a/app/api/new_releases.py
+++ b/app/api/new_releases.py
@@ -25,9 +25,10 @@ from clients.client_lidarr import LidarrClient
 from clients.client_musicbrainz import MusicBrainzClient
 from clients.client_spotify import SpotifyClient
 from commands.config_adapter import ConfigAdapter
-from database.config_models import DismissedArtistAlbum, NewReleasePending
+from database.config_models import DismissedArtistAlbum, NewReleaseIgnoredArtist, NewReleasePending
 from database.database import get_config_db, get_database_manager
 from utils.logger import get_logger
+from utils.release_date import RELEASE_WITHIN_CHOICES, release_date_within
 from utils.text_normalizer import normalize_text, prefer_base_releases, strip_edition_suffix
 
 router = APIRouter()
@@ -389,21 +390,43 @@ async def get_pending_releases(
     status: Annotated[
         str | None, Query(description="Filter: pending, recheck_requested, resolved, dismissed")
     ] = "pending",
+    release_within: Annotated[
+        str | None,
+        Query(
+            description="Release date window: all, 30d, 60d, 90d, 180d, this_year",
+        ),
+    ] = "all",
     limit: Annotated[int, Query(ge=1, le=500)] = 100,
     offset: Annotated[int, Query(ge=0)] = 0,
     db: Session = Depends(get_config_db),
 ):
     """List pending new releases from DB (paginated)."""
     get_logger("cmdarr.api.new_releases")
+    within = (release_within or "all").strip().lower()
+    if within not in RELEASE_WITHIN_CHOICES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid release_within; use one of: {', '.join(sorted(RELEASE_WITHIN_CHOICES))}",
+        )
+
+    ignored_mbids = {r.artist_mbid for r in db.query(NewReleaseIgnoredArtist.artist_mbid).all()}
     q = db.query(NewReleasePending).filter(NewReleasePending.status == status)
-    total = q.count()
-    rows = q.order_by(NewReleasePending.added_at.desc()).offset(offset).limit(limit).all()
+    if ignored_mbids:
+        q = q.filter(~NewReleasePending.artist_mbid.in_(ignored_mbids))
+
+    rows = q.order_by(NewReleasePending.added_at.desc()).all()
+    if within != "all":
+        rows = [r for r in rows if release_date_within(r.release_date, within)]
+
+    total = len(rows)
+    page = rows[offset : offset + limit]
     return {
         "success": True,
         "total": total,
         "limit": limit,
         "offset": offset,
-        "items": [_pending_to_dict(r) for r in rows],
+        "release_within": within,
+        "items": [_pending_to_dict(r) for r in page],
     }
 
 
@@ -459,6 +482,86 @@ async def ignore_release(item_id: int, db: Annotated[Session, Depends(get_config
     row.resolved_reason = "manual_ignore"
     db.commit()
     return {"success": True, "message": "Ignored"}
+
+
+class IgnoreArtistRequest(BaseModel):
+    artist_mbid: str
+    artist_name: str | None = None
+
+
+@router.get("/new-releases/ignored-artists")
+async def list_ignored_artists(
+    limit: Annotated[int, Query(ge=1, le=500)] = 200,
+    db: Session = Depends(get_config_db),
+):
+    rows = (
+        db.query(NewReleaseIgnoredArtist)
+        .order_by(NewReleaseIgnoredArtist.ignored_at.desc())
+        .limit(limit)
+        .all()
+    )
+    return {
+        "success": True,
+        "total": len(rows),
+        "items": [
+            {
+                "artist_mbid": r.artist_mbid,
+                "artist_name": r.artist_name or "",
+                "ignored_at": r.ignored_at.isoformat() if r.ignored_at else None,
+            }
+            for r in rows
+        ],
+    }
+
+
+@router.post("/new-releases/ignore-artist")
+async def ignore_artist(body: IgnoreArtistRequest, db: Annotated[Session, Depends(get_config_db)]):
+    """Stop tracking new releases for an artist; clears their pending rows."""
+    mbid = (body.artist_mbid or "").strip()
+    if not mbid:
+        raise HTTPException(status_code=400, detail="artist_mbid required")
+
+    existing = (
+        db.query(NewReleaseIgnoredArtist)
+        .filter(NewReleaseIgnoredArtist.artist_mbid == mbid)
+        .first()
+    )
+    if not existing:
+        db.add(
+            NewReleaseIgnoredArtist(
+                artist_mbid=mbid,
+                artist_name=(body.artist_name or "")[:500] or None,
+            )
+        )
+
+    removed = (
+        db.query(NewReleasePending)
+        .filter(
+            NewReleasePending.artist_mbid == mbid,
+            NewReleasePending.status == "pending",
+        )
+        .delete(synchronize_session=False)
+    )
+    db.commit()
+    return {
+        "success": True,
+        "message": "Artist will no longer be tracked for new releases",
+        "pending_removed": removed,
+    }
+
+
+@router.post("/new-releases/unignore-artist/{artist_mbid}")
+async def unignore_artist(artist_mbid: str, db: Annotated[Session, Depends(get_config_db)]):
+    row = (
+        db.query(NewReleaseIgnoredArtist)
+        .filter(NewReleaseIgnoredArtist.artist_mbid == artist_mbid)
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Artist not on ignore list")
+    db.delete(row)
+    db.commit()
+    return {"success": True, "message": "Artist tracking restored"}
 
 
 @router.post("/new-releases/dismiss/{item_id}")

--- a/commands/new_releases_discovery.py
+++ b/commands/new_releases_discovery.py
@@ -29,7 +29,12 @@ from clients.client_deezer import DeezerClient
 from clients.client_lidarr import LidarrClient
 from clients.client_musicbrainz import MusicBrainzClient
 from clients.client_spotify import SpotifyClient
-from database.config_models import ArtistScanLog, DismissedArtistAlbum, NewReleasePending
+from database.config_models import (
+    ArtistScanLog,
+    DismissedArtistAlbum,
+    NewReleaseIgnoredArtist,
+    NewReleasePending,
+)
 from database.database import get_database_manager
 from utils.text_normalizer import normalize_text, prefer_base_releases, strip_edition_suffix
 
@@ -202,6 +207,12 @@ class NewReleasesDiscoveryCommand(BaseCommand):
                                 )
 
                                 if not artist_name or not mbid:
+                                    continue
+
+                                if self._is_artist_ignored(session, mbid):
+                                    self.logger.debug(
+                                        f"Skipping '{artist_name}': artist on do-not-track list"
+                                    )
                                     continue
 
                                 # Try Lidarr links first - validate with fuzzy match
@@ -443,6 +454,9 @@ class NewReleasesDiscoveryCommand(BaseCommand):
         try:
             rows = session.query(ArtistScanLog).all()
             log_by_mbid = {r.artist_mbid: r for r in rows}
+            ignored_mbids = {
+                r.artist_mbid for r in session.query(NewReleaseIgnoredArtist.artist_mbid).all()
+            }
         finally:
             session.close()
 
@@ -450,7 +464,7 @@ class NewReleasesDiscoveryCommand(BaseCommand):
         scanned = []
         for a in artists:
             mbid = a.get("musicBrainzId")
-            if not mbid:
+            if not mbid or mbid in ignored_mbids:
                 continue
             if mbid not in log_by_mbid:
                 never_scanned.append(a)
@@ -479,6 +493,14 @@ class NewReleasesDiscoveryCommand(BaseCommand):
                     had_pending_releases=had_pending,
                 )
             )
+
+    def _is_artist_ignored(self, session: Session, artist_mbid: str) -> bool:
+        return (
+            session.query(NewReleaseIgnoredArtist)
+            .filter(NewReleaseIgnoredArtist.artist_mbid == artist_mbid)
+            .first()
+            is not None
+        )
 
     def _is_dismissed(
         self, session: Session, artist_mbid: str, album_title: str, release_date: str

--- a/database/config_models.py
+++ b/database/config_models.py
@@ -209,6 +209,16 @@ class DismissedArtistAlbum(ConfigBase):
     )
 
 
+class NewReleaseIgnoredArtist(ConfigBase):
+    """Artists excluded from new release discovery and pending list."""
+
+    __tablename__ = "new_release_ignored_artist"
+
+    artist_mbid = Column(String(100), primary_key=True)
+    artist_name = Column(String(500), nullable=True)
+    ignored_at = Column(DateTime(timezone=True), server_default=func.now())
+
+
 class ArtistEvent(ConfigBase):
     """Canonical live event row (shows, festivals, meet-and-greets, etc.) after cross-provider dedupe."""
 

--- a/database/version_migrations.py
+++ b/database/version_migrations.py
@@ -514,6 +514,25 @@ def create_version_migration_runner() -> VersionMigrationRunner:
         normalize_concert_event_place_fields(cursor)
         coalesce_concert_event_duplicates(cursor)
 
+    def migrate_new_release_ignored_artist(cursor):
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS new_release_ignored_artist (
+                artist_mbid VARCHAR(100) PRIMARY KEY,
+                artist_name VARCHAR(500),
+                ignored_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+
+    runner.add_migration(
+        VersionMigration(
+            version="0.3.16",
+            name="new_release_ignored_artist",
+            description="Add new_release_ignored_artist for do-not-track artist list",
+            up_func=migrate_new_release_ignored_artist,
+            applied_check=lambda c: _table_exists(c, "new_release_ignored_artist"),
+        )
+    )
+
     runner.add_migration(
         VersionMigration(
             version="0.3.16",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -11,6 +11,7 @@ import type {
   StatusInfo,
   MigrationStatus,
   NrdMetrics,
+  NewReleaseIgnoredArtist,
   NewReleasesResponse,
   PendingReleasesResponse,
   LidarrArtistSuggestion,
@@ -316,11 +317,13 @@ class ApiClient {
     status?: string;
     limit?: number;
     offset?: number;
+    release_within?: string;
   }): Promise<PendingReleasesResponse> {
     const searchParams = new URLSearchParams();
     if (params?.status) searchParams.set("status", params.status);
     if (params?.limit !== undefined) searchParams.set("limit", String(params.limit));
     if (params?.offset !== undefined) searchParams.set("offset", String(params.offset));
+    if (params?.release_within) searchParams.set("release_within", params.release_within);
     const query = searchParams.toString();
     return this.request<PendingReleasesResponse>(
       `/api/new-releases/pending${query ? `?${query}` : ""}`
@@ -337,6 +340,30 @@ class ApiClient {
 
   async ignoreRelease(itemId: number): Promise<{ success: boolean }> {
     return this.request(`/api/new-releases/ignore/${itemId}`, { method: "POST" });
+  }
+
+  async getIgnoredReleaseArtists(): Promise<{
+    success: boolean;
+    total: number;
+    items: NewReleaseIgnoredArtist[];
+  }> {
+    return this.request("/api/new-releases/ignored-artists");
+  }
+
+  async ignoreReleaseArtist(body: {
+    artist_mbid: string;
+    artist_name?: string;
+  }): Promise<{ success: boolean; pending_removed?: number }> {
+    return this.request("/api/new-releases/ignore-artist", {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+  }
+
+  async unignoreReleaseArtist(artistMbid: string): Promise<{ success: boolean }> {
+    return this.request(`/api/new-releases/unignore-artist/${encodeURIComponent(artistMbid)}`, {
+      method: "POST",
+    });
   }
 
   async recheckRelease(itemId: number): Promise<{ success: boolean; removed?: boolean }> {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -202,12 +202,21 @@ export interface NewReleasePendingItem {
   status: string;
 }
 
+export type ReleaseWithinFilter = "all" | "30d" | "60d" | "90d" | "180d" | "this_year";
+
 export interface PendingReleasesResponse {
   success: boolean;
   total: number;
   limit: number;
   offset: number;
+  release_within?: ReleaseWithinFilter;
   items: NewReleasePendingItem[];
+}
+
+export interface NewReleaseIgnoredArtist {
+  artist_mbid: string;
+  artist_name: string;
+  ignored_at?: string | null;
 }
 
 export interface ScanArtistUrlAlbum {

--- a/frontend/src/pages/NewReleases.tsx
+++ b/frontend/src/pages/NewReleases.tsx
@@ -10,14 +10,40 @@ import {
   RefreshCw,
   Ban,
   Link2,
+  UserX,
+  RotateCcw,
 } from "lucide-react";
 import { api } from "@/lib/api";
-import type { NewReleasePendingItem } from "@/lib/types";
+import type { NewReleasePendingItem, ReleaseWithinFilter } from "@/lib/types";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { toast } from "sonner";
+
+const RELEASE_WITHIN_OPTIONS: { value: ReleaseWithinFilter; label: string }[] = [
+  { value: "all", label: "All dates" },
+  { value: "30d", label: "Last 30 days" },
+  { value: "60d", label: "Last 60 days" },
+  { value: "90d", label: "Last 90 days" },
+  { value: "180d", label: "Last 180 days" },
+  { value: "this_year", label: "This year" },
+];
 
 /** Returns display label for release URL based on hostname (avoids substring matching). */
 function getReleaseUrlLabel(url: string): string {
@@ -65,6 +91,14 @@ export function NewReleasesPage() {
   const [artistScanning, setArtistScanning] = useState(false);
   const [confirmClearAll, setConfirmClearAll] = useState(false);
   const [ignoreTarget, setIgnoreTarget] = useState<NewReleasePendingItem | null>(null);
+  const [dontTrackTarget, setDontTrackTarget] = useState<NewReleasePendingItem | null>(null);
+  const [releaseWithin, setReleaseWithin] = useState<ReleaseWithinFilter>("90d");
+  const [ignoredArtistsOpen, setIgnoredArtistsOpen] = useState(false);
+  const [ignoredArtists, setIgnoredArtists] = useState<
+    { artist_mbid: string; artist_name: string; ignored_at?: string | null }[]
+  >([]);
+  const [ignoredArtistsLoading, setIgnoredArtistsLoading] = useState(false);
+  const [dontTrackLoading, setDontTrackLoading] = useState(false);
   const [clearAllLoading, setClearAllLoading] = useState(false);
   const [ignoreLoading, setIgnoreLoading] = useState(false);
 
@@ -90,7 +124,11 @@ export function NewReleasesPage() {
     setLoading(true);
     setError(null);
     try {
-      const data = await api.getPendingReleases({ status: "pending", limit: 200 });
+      const data = await api.getPendingReleases({
+        status: "pending",
+        limit: 200,
+        release_within: releaseWithin,
+      });
       setPending(data.items);
       setTotal(data.total);
     } catch (err) {
@@ -104,6 +142,18 @@ export function NewReleasesPage() {
       toast.error(msg);
     } finally {
       setLoading(false);
+    }
+  }, [releaseWithin]);
+
+  const loadIgnoredArtists = useCallback(async () => {
+    setIgnoredArtistsLoading(true);
+    try {
+      const res = await api.getIgnoredReleaseArtists();
+      setIgnoredArtists(res.items);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to load ignored artists");
+    } finally {
+      setIgnoredArtistsLoading(false);
     }
   }, []);
 
@@ -156,6 +206,44 @@ export function NewReleasesPage() {
       toast.error(err instanceof Error ? err.message : "Clear all failed");
     } finally {
       setClearAllLoading(false);
+    }
+  };
+
+  const handleDontTrackArtist = (item: NewReleasePendingItem) => {
+    setDontTrackTarget(item);
+  };
+
+  const doDontTrackArtist = async () => {
+    if (!dontTrackTarget) return;
+    setDontTrackLoading(true);
+    try {
+      const res = await api.ignoreReleaseArtist({
+        artist_mbid: dontTrackTarget.artist_mbid,
+        artist_name: dontTrackTarget.artist_name,
+      });
+      setPending((prev) => prev.filter((p) => p.artist_mbid !== dontTrackTarget.artist_mbid));
+      setTotal((t) => Math.max(0, t - (res.pending_removed ?? 0)));
+      setDontTrackTarget(null);
+      toast.success(`${dontTrackTarget.artist_name} will no longer be tracked for new releases`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Could not update artist tracking");
+    } finally {
+      setDontTrackLoading(false);
+    }
+  };
+
+  const openIgnoredArtists = () => {
+    setIgnoredArtistsOpen(true);
+    void loadIgnoredArtists();
+  };
+
+  const restoreIgnoredArtist = async (artistMbid: string) => {
+    try {
+      await api.unignoreReleaseArtist(artistMbid);
+      setIgnoredArtists((prev) => prev.filter((a) => a.artist_mbid !== artistMbid));
+      toast.success("Artist tracking restored");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Restore failed");
     }
   };
 
@@ -537,20 +625,48 @@ export function NewReleasesPage() {
       {/* Pending table */}
       <Card>
         <CardHeader>
-          <div className="flex flex-wrap items-start justify-between gap-2">
-            <div>
-              <CardTitle>Pending Releases</CardTitle>
-              <CardDescription>
-                {total} items. Use links to open Lidarr, MusicBrainz, release source
-                (Deezer/Spotify), or Add to MB (Harmony). Actions: Clear (reappears), Recheck
-                (verify MB), Ignore (never show).
-              </CardDescription>
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <div className="min-w-0">
+                <CardTitle>Pending Releases</CardTitle>
+                <CardDescription>
+                  {total} items matching filters. Links open Lidarr, MusicBrainz, or release source.
+                  Clear reappears on rescan; Ignore hides one album; Don&apos;t track skips the
+                  artist entirely.
+                </CardDescription>
+              </div>
+              <div className="flex shrink-0 flex-wrap gap-2">
+                <Button variant="outline" size="sm" onClick={openIgnoredArtists}>
+                  <UserX className="mr-2 h-4 w-4" />
+                  Don&apos;t track
+                </Button>
+                {pending.length > 0 && (
+                  <Button variant="outline" size="sm" onClick={handleClearAll}>
+                    Clear all
+                  </Button>
+                )}
+              </div>
             </div>
-            {pending.length > 0 && (
-              <Button variant="outline" size="sm" onClick={handleClearAll} className="shrink-0">
-                Clear all
-              </Button>
-            )}
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:gap-4">
+              <div className="w-full space-y-1.5 sm:w-52">
+                <Label className="text-xs text-muted-foreground">Release date</Label>
+                <Select
+                  value={releaseWithin}
+                  onValueChange={(v) => setReleaseWithin(v as ReleaseWithinFilter)}
+                >
+                  <SelectTrigger className="h-9">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {RELEASE_WITHIN_OPTIONS.map((opt) => (
+                      <SelectItem key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
           </div>
         </CardHeader>
         <CardContent>
@@ -564,7 +680,9 @@ export function NewReleasesPage() {
                 <Disc3 className="mx-auto h-12 w-12 opacity-50" />
                 <p className="mt-2 font-medium">No pending releases</p>
                 <p className="mt-1 text-sm">
-                  Run a batch or scan an artist to discover new releases.
+                  {releaseWithin === "all"
+                    ? "Run a batch or scan an artist to discover new releases."
+                    : "Try a wider release date filter or run a new scan."}
                 </p>
               </div>
             </div>
@@ -577,6 +695,7 @@ export function NewReleasesPage() {
                   onClear={() => handleClear(item)}
                   onRecheck={() => handleRecheck(item)}
                   onIgnore={() => handleIgnore(item)}
+                  onDontTrackArtist={() => handleDontTrackArtist(item)}
                   onOpenHarmony={openHarmony}
                 />
               ))}
@@ -602,10 +721,65 @@ export function NewReleasesPage() {
             ? `Ignore "${ignoreTarget.album_title}" by ${ignoreTarget.artist_name}? It won't reappear. Restore from Status if needed.`
             : null
         }
-        confirmLabel="Ignore"
+        confirmLabel="Ignore release"
         onConfirm={doIgnore}
         isLoading={ignoreLoading}
       />
+      <ConfirmDialog
+        open={dontTrackTarget !== null}
+        onOpenChange={(open) => !open && setDontTrackTarget(null)}
+        title="Don't track this artist?"
+        description={
+          dontTrackTarget
+            ? `"${dontTrackTarget.artist_name}" will be removed from pending and skipped on future discovery scans. Restore from Don't track list on this page.`
+            : null
+        }
+        confirmLabel="Don't track artist"
+        onConfirm={doDontTrackArtist}
+        isLoading={dontTrackLoading}
+      />
+      <Dialog open={ignoredArtistsOpen} onOpenChange={setIgnoredArtistsOpen}>
+        <DialogContent className="max-w-lg max-h-[80vh] overflow-hidden flex flex-col">
+          <DialogHeader>
+            <DialogTitle>Artists not tracked</DialogTitle>
+            <DialogDescription>
+              These artists are excluded from scheduled discovery and pending list. Restore to scan
+              them again.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex-1 overflow-y-auto space-y-2">
+            {ignoredArtistsLoading ? (
+              <div className="flex justify-center py-8">
+                <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+              </div>
+            ) : ignoredArtists.length === 0 ? (
+              <p className="py-6 text-center text-sm text-muted-foreground">
+                No artists on the don&apos;t-track list.
+              </p>
+            ) : (
+              ignoredArtists.map((artist) => (
+                <div
+                  key={artist.artist_mbid}
+                  className="flex flex-col gap-2 rounded-lg border p-3 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div className="min-w-0 font-medium">
+                    {artist.artist_name || artist.artist_mbid}
+                  </div>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="shrink-0 self-start sm:self-auto"
+                    onClick={() => restoreIgnoredArtist(artist.artist_mbid)}
+                  >
+                    <RotateCcw className="mr-1.5 h-3.5 w-3.5" />
+                    Restore
+                  </Button>
+                </div>
+              ))
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }
@@ -615,12 +789,14 @@ function PendingRow({
   onClear,
   onRecheck,
   onIgnore,
+  onDontTrackArtist,
   onOpenHarmony,
 }: {
   item: NewReleasePendingItem;
   onClear: () => void;
   onRecheck: () => void;
   onIgnore: () => void;
+  onDontTrackArtist: () => void;
   onOpenHarmony: (url: string) => void;
 }) {
   return (
@@ -672,6 +848,16 @@ function PendingRow({
             variant="ghost"
             size="icon"
             className="h-8 w-8 shrink-0 text-muted-foreground hover:text-foreground"
+            onClick={onDontTrackArtist}
+            title="Don't track this artist for new releases"
+            aria-label="Don't track artist"
+          >
+            <UserX className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 shrink-0 text-muted-foreground hover:text-foreground"
             onClick={onClear}
             title="Clear for now, will reappear on rescan"
             aria-label="Clear release"
@@ -693,7 +879,7 @@ function PendingRow({
             size="icon"
             className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive"
             onClick={onIgnore}
-            title="Never show again"
+            title="Ignore this album permanently"
             aria-label="Ignore release"
           >
             <Ban className="h-4 w-4" />

--- a/tests/test_release_date.py
+++ b/tests/test_release_date.py
@@ -1,0 +1,28 @@
+from datetime import date
+
+from utils.release_date import parse_release_date, release_date_within, release_within_cutoff
+
+
+def test_parse_release_date_formats():
+    assert parse_release_date("2024-05-15") == date(2024, 5, 15)
+    assert parse_release_date("2024-05") == date(2024, 5, 1)
+    assert parse_release_date("2024") == date(2024, 1, 1)
+    assert parse_release_date("") is None
+
+
+def test_release_date_within_recent():
+    today = date.today()
+    assert release_date_within(today.isoformat(), "30d") is True
+    assert release_date_within("1999-01-01", "30d") is False
+    assert release_date_within(f"{today.year}-01-15", "this_year") is True
+    assert release_date_within("2019-12-31", "this_year") is False
+
+
+def test_release_date_within_all():
+    assert release_date_within("1999-01-01", "all") is True
+    assert release_date_within(None, "all") is True
+
+
+def test_release_within_cutoff_this_year():
+    cutoff = release_within_cutoff("this_year")
+    assert cutoff == date(date.today().year, 1, 1)

--- a/utils/release_date.py
+++ b/utils/release_date.py
@@ -1,0 +1,50 @@
+"""Helpers for comparing Spotify/Deezer release_date strings (YYYY, YYYY-MM, YYYY-MM-DD)."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+RELEASE_WITHIN_CHOICES = frozenset({"all", "30d", "60d", "90d", "180d", "this_year"})
+
+
+def parse_release_date(value: str | None) -> date | None:
+    if not value:
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    try:
+        if len(text) >= 10:
+            return date.fromisoformat(text[:10])
+        if len(text) >= 7:
+            year, month = text[:7].split("-", 1)
+            return date(int(year), int(month), 1)
+        if len(text) >= 4 and text[:4].isdigit():
+            return date(int(text[:4]), 1, 1)
+    except ValueError, TypeError:
+        return None
+    return None
+
+
+def release_within_cutoff(within: str) -> date | None:
+    """Earliest release date (inclusive) for a within filter."""
+    today = date.today()
+    if within == "this_year":
+        return date(today.year, 1, 1)
+    days_map = {"30d": 30, "60d": 60, "90d": 90, "180d": 180}
+    days = days_map.get(within)
+    if days is None:
+        return None
+    return today - timedelta(days=days)
+
+
+def release_date_within(value: str | None, within: str) -> bool:
+    if not within or within == "all":
+        return True
+    parsed = parse_release_date(value)
+    if parsed is None:
+        return False
+    cutoff = release_within_cutoff(within)
+    if cutoff is None:
+        return True
+    return parsed >= cutoff


### PR DESCRIPTION
Skip ignored artists during discovery scans, expose ignore/restore APIs and UI, and filter pending releases by recency so old untracked albums are easier to ignore.