### PR TITLE
Unify Spotify client: optional creds with scraper fallback.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.17-dev] - TBD
 
 ### Features
-- **New Releases Discovery — Spotify (scraper)**: Optional release source using public Spotify catalog via spotifyscraper — no Spotify API credentials or Premium required. Deezer remains the default; switch in Commands → Edit to compare catalogs (e.g. when Deezer attaches wrong albums to an artist page).
+- **Unified Spotify client**: Optional Client ID/Secret app-wide; official API when credentials are valid, spotifyscraper as default and fallback for playlist sync, NRD, and scan-by-URL. NRD release source picker shows Deezer or Spotify only.
 - **NRD Spotify performance**: Artist discography is fetched in one paginated pass per artist; `get_album` runs only for releases that do not match MusicBrainz, before creating pending rows.
 
 ### Fixes

--- a/app/api/commands.py
+++ b/app/api/commands.py
@@ -346,32 +346,6 @@ async def update_command(
             command.timeout_minutes = request.timeout_minutes
         if request.config_json is not None:
             prev_config_snapshot = dict(command.config_json or {})
-            # Validate Spotify credentials and API access when switching NRD to Spotify source
-            if command_name == "new_releases_discovery":
-                from utils.nrd_release_source import normalize_nrd_source
-
-                src = normalize_nrd_source(request.config_json.get("new_releases_source"))
-                if src == "spotify":
-                    from clients.client_spotify import SpotifyClient
-                    from commands.config_adapter import ConfigAdapter
-
-                    config = ConfigAdapter()
-                    if not config.SPOTIFY_CLIENT_ID or not config.SPOTIFY_CLIENT_SECRET:
-                        raise HTTPException(
-                            status_code=400,
-                            detail="Spotify credentials must be set in Config → Music Sources before using Spotify as the release source.",
-                        )
-                    # Verify API actually works (e.g. not 403 Premium required)
-                    client = SpotifyClient(config)
-                    try:
-                        connected = await client.test_connection()
-                        if not connected:
-                            raise HTTPException(
-                                status_code=400,
-                                detail="Spotify API requires Premium for Development Mode. Use Deezer as the release source instead.",
-                            )
-                    finally:
-                        await client.close()
             command.config_json = request.config_json
             # Playlist generators: keep display_name in sync with playlist title on save; delete prior
             # playlist on Plex/Jellyfin when title or target changes so orphans are not left behind.
@@ -2328,13 +2302,16 @@ async def get_new_releases_sources():
                 "id": "deezer",
                 "name": "Deezer",
                 "configured": True,
-                "config_help": "No account required—uses public data",
+                "config_help": "Uses open API",
             },
             {
-                "id": "spotify_scraper",
+                "id": "spotify",
                 "name": "Spotify",
                 "configured": scraper_ok,
-                "config_help": "Public catalog via scraper; no account required",
+                "config_help": (
+                    "Defaults to spotifyscraper unless valid client creds are configured, "
+                    "in which case the official API is used"
+                ),
             },
         ]
 
@@ -2349,18 +2326,16 @@ async def get_new_releases_sources():
 async def get_playlist_sync_sources():
     """Get available playlist sync sources and their configuration status"""
     try:
-        from commands.config_adapter import Config
-
-        config = Config()
-
         sources = [
             {
                 "id": "spotify",
                 "name": "Spotify",
                 "requires_url": True,
                 "example_url": "https://open.spotify.com/playlist/4NDXWHwYWjFmgVPkNy4YlF",
-                "configured": bool(config.SPOTIFY_CLIENT_ID and config.SPOTIFY_CLIENT_SECRET),
-                "config_help": "For public playlists; optional—scraper used when not configured",
+                "configured": True,
+                "config_help": (
+                    "Optional client creds enable official API; otherwise spotifyscraper is used"
+                ),
             },
             {
                 "id": "deezer",

--- a/app/api/new_releases.py
+++ b/app/api/new_releases.py
@@ -29,7 +29,7 @@ from database.config_models import DismissedArtistAlbum, NewReleaseIgnoredArtist
 from database.database import get_config_db, get_database_manager
 from utils.logger import get_logger
 from utils.nrd_release_source import (
-    enrich_scraper_nrd_album,
+    enrich_nrd_album_if_needed,
     normalize_nrd_source,
     nrd_lidarr_artist_id_key,
     nrd_mb_streaming_provider,
@@ -178,12 +178,6 @@ async def get_new_releases(
     config = ConfigAdapter()
 
     source_provider = _get_new_releases_source_from_db()
-    if normalize_nrd_source(source_provider) == "spotify":
-        if not config.SPOTIFY_CLIENT_ID or not config.SPOTIFY_CLIENT_SECRET:
-            raise HTTPException(
-                status_code=503,
-                detail="Spotify credentials not configured (new_releases_source=spotify).",
-            )
     if not config.LIDARR_API_KEY or not config.LIDARR_URL:
         raise HTTPException(
             status_code=503,
@@ -286,9 +280,9 @@ async def get_new_releases(
                         continue
 
                 new_albums = []
-                scraper_source = normalize_nrd_source(source_provider) == "spotify_scraper"
+                via_scraper = albums_result.get("via") == "scraper"
                 for album in albums_result["albums"]:
-                    if not scraper_source and album.get("primary_artist_id") != artist_id:
+                    if not via_scraper and album.get("primary_artist_id") != artist_id:
                         skipped_type += 1
                         continue
 
@@ -307,7 +301,7 @@ async def get_new_releases(
                         skipped_in_mb += 1
                         continue
 
-                    album = await enrich_scraper_nrd_album(release_client, album, source_provider)
+                    album = await enrich_nrd_album_if_needed(release_client, album, source_provider)
                     if album.get("primary_artist_id") != artist_id:
                         skipped_type += 1
                         continue
@@ -908,10 +902,10 @@ async def _maybe_enrich_and_build_missing(
     *,
     source: str,
     mb_titles: list[str] | None = None,
+    via_scraper: bool = False,
 ) -> dict | None:
     """Filter on discography catalog; enrich via get_album only for MB non-matches."""
-    scraper_source = normalize_nrd_source(source) == "spotify_scraper"
-    if not scraper_source and str(album.get("primary_artist_id", "")) != str(artist_id):
+    if not via_scraper and str(album.get("primary_artist_id", "")) != str(artist_id):
         return None
     album_type = album.get("album_type", "")
     total_tracks = album.get("total_tracks", 0)
@@ -921,7 +915,7 @@ async def _maybe_enrich_and_build_missing(
         return None
     if mb_titles is not None and _title_matches_mb(album.get("name", ""), mb_titles):
         return None
-    album = await enrich_scraper_nrd_album(release_client, album, source)
+    album = await enrich_nrd_album_if_needed(release_client, album, source)
     return _build_missing_album(album, artist_id, selected)
 
 
@@ -956,7 +950,7 @@ async def scan_artist_url(body: ScanArtistUrlRequest) -> ScanArtistUrlResponse:
         selected = {"album", "ep", "single"}
 
     if provider == "spotify":
-        release_client = SpotifyClient(config, discography_source="scraper")
+        release_client = SpotifyClient(config)
     else:
         release_client = DeezerClient(config)
 
@@ -1021,6 +1015,7 @@ async def scan_artist_url(body: ScanArtistUrlRequest) -> ScanArtistUrlResponse:
             if not albums_result.get("success") or albums_result.get("error"):
                 raise HTTPException(status_code=500, detail="Failed to fetch albums")
             albums = albums_result.get("albums", [])
+            albums_via_scraper = albums_result.get("via") == "scraper"
     except HTTPException:
         raise
     except Exception:
@@ -1031,7 +1026,7 @@ async def scan_artist_url(body: ScanArtistUrlRequest) -> ScanArtistUrlResponse:
         """Run MusicBrainz scan. Raises HTTPException on error."""
         mb_artist_mbid: str | None = None
         best_missing: list[dict] = []
-        catalog_source = "spotify_scraper" if provider == "spotify" else "deezer"
+        catalog_source = "spotify" if provider == "spotify" else "deezer"
         async with MusicBrainzClient(config) as mb_client:
             candidates = await mb_client.search_artist_candidates(artist_name, limit=5)
 
@@ -1054,6 +1049,7 @@ async def scan_artist_url(body: ScanArtistUrlRequest) -> ScanArtistUrlResponse:
                             selected,
                             source=catalog_source,
                             mb_titles=titles,
+                            via_scraper=albums_via_scraper,
                         )
                         if item:
                             best_missing.append(item)
@@ -1090,6 +1086,7 @@ async def scan_artist_url(body: ScanArtistUrlRequest) -> ScanArtistUrlResponse:
                                         selected,
                                         source=catalog_source,
                                         mb_titles=titles,
+                                        via_scraper=albums_via_scraper,
                                     )
                                     if item:
                                         best_missing.append(item)
@@ -1107,6 +1104,7 @@ async def scan_artist_url(body: ScanArtistUrlRequest) -> ScanArtistUrlResponse:
                         selected,
                         source=catalog_source,
                         mb_titles=None,
+                        via_scraper=albums_via_scraper,
                     )
                     if item:
                         best_missing.append(item)

--- a/app/api/test_connectivity.py
+++ b/app/api/test_connectivity.py
@@ -395,42 +395,28 @@ async def _test_musicbrainz() -> ConnectivityTestResult:
 
 
 async def _test_spotify() -> ConnectivityTestResult:
-    """Test Spotify connectivity"""
+    """Test Spotify connectivity (official API when configured, scraper as fallback)."""
     try:
-        # Check if Spotify is configured
-        spotify_client_id = config_service.get("SPOTIFY_CLIENT_ID")
-        spotify_client_secret = config_service.get("SPOTIFY_CLIENT_SECRET")
-
-        if not spotify_client_id or not spotify_client_secret:
-            return ConnectivityTestResult(
-                service="Spotify",
-                success=False,
-                message="Not configured",
-                error="Spotify Client ID or Client Secret not set",
-                status="warning",
-            )
-
-        # Test connection
         from clients.client_spotify import SpotifyClient
 
         config = ConfigAdapter()
 
         async with SpotifyClient(config) as client:
-            # Use the existing test_connection method
-            success = await client.test_connection()
+            detail = await client.test_connection_detail()
 
+        success = detail.get("success", False)
+        message = detail.get("message", "Connection failed")
         if success:
             return ConnectivityTestResult(
-                service="Spotify", success=True, message="Connected successfully", status="success"
+                service="Spotify", success=True, message=message, status="success"
             )
-        else:
-            return ConnectivityTestResult(
-                service="Spotify",
-                success=False,
-                message="Connection failed",
-                error="Unable to authenticate with Spotify API",
-                status="error",
-            )
+        return ConnectivityTestResult(
+            service="Spotify",
+            success=False,
+            message=message,
+            error=message,
+            status="error",
+        )
 
     except Exception as e:
         get_test_connectivity_logger().error(f"Spotify test failed: {e}")

--- a/clients/client_spotify.py
+++ b/clients/client_spotify.py
@@ -427,7 +427,7 @@ def probe_scraper_discography(artist_id: str = "4Z8W4fKeB5YxbusRsdQVPb") -> bool
 class SpotifyClient(BaseAPIClient):
     """Client for Spotify API operations"""
 
-    def __init__(self, config, discography_source: str = "api"):
+    def __init__(self, config):
         super().__init__(
             config=config,
             client_name="spotify",
@@ -436,9 +436,6 @@ class SpotifyClient(BaseAPIClient):
             headers={},
         )
 
-        self.discography_source = (
-            discography_source if discography_source in ("api", "scraper") else "api"
-        )
         self.client_id = config.SPOTIFY_CLIENT_ID
         self.client_secret = config.SPOTIFY_CLIENT_SECRET
         self.access_token = None
@@ -525,9 +522,40 @@ class SpotifyClient(BaseAPIClient):
         self._update_api_cache(usable)
         if not usable:
             self.logger.info(
-                "Spotify API cached as unusable (403 Premium required) - using scraper for playlist sync"
+                "Spotify API cached as unusable (403 Premium required) - using scraper"
             )
         return usable
+
+    async def _can_try_api(self) -> bool:
+        """True when credentials are present and API is not cached as unusable."""
+        if not self._has_credentials():
+            return False
+        if self._should_skip_api():
+            return False
+        if self._get_api_usable_cached() is None:
+            return await self._ensure_api_evaluated()
+        return True
+
+    async def _api_or_scraper(
+        self,
+        operation: str,
+        api_fn,
+        scraper_fn,
+        *,
+        tag_via: bool = False,
+    ) -> dict[str, Any]:
+        """Try official API when usable; fall back to spotifyscraper on failure."""
+        if await self._can_try_api():
+            api_result = await api_fn()
+            if api_result.get("success"):
+                if tag_via:
+                    api_result["via"] = "api"
+                return api_result
+            self.logger.info(f"Spotify API unavailable for {operation} — using scraper")
+        scraper_result = await scraper_fn()
+        if tag_via and scraper_result.get("success"):
+            scraper_result["via"] = "scraper"
+        return scraper_result
 
     async def _get_playlist_via_scraper(self, url: str) -> dict[str, Any]:
         """Run sync scraper in executor."""
@@ -538,16 +566,46 @@ class SpotifyClient(BaseAPIClient):
         loop = asyncio.get_event_loop()
         return await loop.run_in_executor(None, lambda: func(*args, **kwargs))
 
+    async def _enrich_nrd_album_api(self, album_id: str, fallback_artist_id: str | None) -> dict[str, Any]:
+        result = await self._get(f"/albums/{album_id}")
+        if not result:
+            return {"success": False, "album": None}
+        artists = result.get("artists", [])
+        primary_artist_id = fallback_artist_id
+        if artists and isinstance(artists[0], dict):
+            primary_artist_id = artists[0].get("id") or primary_artist_id
+        external_url = result.get("external_urls", {}).get("spotify", "")
+        return {
+            "success": True,
+            "album": {
+                "id": result.get("id", album_id),
+                "name": result.get("name", ""),
+                "release_date": result.get("release_date", ""),
+                "release_date_precision": result.get("release_date_precision", "year"),
+                "album_type": (result.get("album_type") or "album").lower(),
+                "total_tracks": int(result.get("total_tracks") or 0),
+                "primary_artist_id": primary_artist_id,
+                "external_url": external_url,
+                "spotify_url": external_url,
+            },
+        }
+
     async def enrich_nrd_album(self, album: dict[str, Any]) -> dict[str, Any]:
-        """Fetch full album metadata for a discography candidate (scraper mode only)."""
-        if self.discography_source != "scraper":
-            return album
+        """Fetch full album metadata for a discography candidate."""
         album_id = album.get("id")
         if not album_id:
             return album
-        result = await self._run_scraper(
-            _scraper_enrich_nrd_album, album_id, album.get("primary_artist_id")
-        )
+        fallback_artist_id = album.get("primary_artist_id")
+
+        async def api_fn():
+            return await self._enrich_nrd_album_api(album_id, fallback_artist_id)
+
+        async def scraper_fn():
+            return await self._run_scraper(
+                _scraper_enrich_nrd_album, album_id, fallback_artist_id
+            )
+
+        result = await self._api_or_scraper("enrich_nrd_album", api_fn, scraper_fn)
         if result.get("success") and result.get("album"):
             return result["album"]
         return album
@@ -823,10 +881,7 @@ class SpotifyClient(BaseAPIClient):
             self.logger.error(f"Error fetching playlist tracks: {e}")
             return {"success": False, "error": f"Failed to fetch tracks: {str(e)}"}
 
-    async def get_album(self, album_id: str) -> dict[str, Any]:
-        """Get album by ID. Returns artist_id, artist_name, title, album_url, etc."""
-        if self.discography_source == "scraper":
-            return await self._run_scraper(_scraper_get_album, album_id)
+    async def _get_album_api(self, album_id: str) -> dict[str, Any]:
         try:
             result = await self._get(f"/albums/{album_id}")
             if not result:
@@ -850,13 +905,15 @@ class SpotifyClient(BaseAPIClient):
             self.logger.error(f"Error fetching album {album_id}: {e}")
             return {"success": False, "error": str(e)}
 
-    async def get_artist(self, artist_id: str) -> dict[str, Any]:
-        """
-        Get artist by Spotify ID (for name validation when using Lidarr's Spotify link).
-        Returns dict with id, name, or error.
-        """
-        if self.discography_source == "scraper":
-            return await self._run_scraper(_scraper_get_artist, artist_id)
+    async def get_album(self, album_id: str) -> dict[str, Any]:
+        """Get album by ID. Returns artist_id, artist_name, title, album_url, etc."""
+        return await self._api_or_scraper(
+            "get_album",
+            lambda: self._get_album_api(album_id),
+            lambda: self._run_scraper(_scraper_get_album, album_id),
+        )
+
+    async def _get_artist_api(self, artist_id: str) -> dict[str, Any]:
         try:
             result = await self._get(f"/artists/{artist_id}")
             if not result:
@@ -870,13 +927,18 @@ class SpotifyClient(BaseAPIClient):
             self.logger.error(f"Error fetching artist {artist_id}: {e}")
             return {"success": False, "error": str(e), "name": None}
 
-    async def search_artists(self, name: str, limit: int = 5) -> dict[str, Any]:
+    async def get_artist(self, artist_id: str) -> dict[str, Any]:
         """
-        Search for artists by name on Spotify.
-        Feb 2026: search limit max 10 per request; paginate if more needed.
+        Get artist by Spotify ID (for name validation when using Lidarr's Spotify link).
+        Returns dict with id, name, or error.
         """
-        if self.discography_source == "scraper":
-            return await self._run_scraper(_scraper_search_artists, name, limit)
+        return await self._api_or_scraper(
+            "get_artist",
+            lambda: self._get_artist_api(artist_id),
+            lambda: self._run_scraper(_scraper_get_artist, artist_id),
+        )
+
+    async def _search_artists_api(self, name: str, limit: int) -> dict[str, Any]:
         try:
             page_limit = min(limit, 10)
             all_artists = []
@@ -923,63 +985,31 @@ class SpotifyClient(BaseAPIClient):
             self.logger.error(f"Error searching for artist '{name}': {e}")
             return {"success": False, "error": str(e), "artists": []}
 
-    def _get_artist_albums_cache_key(self, artist_id: str) -> str:
-        """Generate cache key for artist albums (v2 includes primary_artist_id)"""
-        if self.discography_source == "scraper":
+    async def search_artists(self, name: str, limit: int = 5) -> dict[str, Any]:
+        """
+        Search for artists by name on Spotify.
+        Feb 2026: search limit max 10 per request; paginate if more needed.
+        """
+        return await self._api_or_scraper(
+            "search_artists",
+            lambda: self._search_artists_api(name, limit),
+            lambda: self._run_scraper(_scraper_search_artists, name, limit),
+        )
+
+    def _get_artist_albums_cache_key(self, artist_id: str, via: str) -> str:
+        """Generate cache key for artist albums (separate keys per data source)."""
+        if via == "scraper":
             return f"spotify_scraper_artist_albums_v1:{artist_id}"
         return f"spotify_artist_albums_v2:{artist_id}"
 
-    async def get_artist_albums(
+    async def _get_artist_albums_api(
         self,
         artist_id: str,
-        limit: int = 50,
-        include_groups: str = "album,single,compilation,appears_on",
-        fetch_all: bool = False,
+        limit: int,
+        include_groups: str,
+        fetch_all: bool,
     ) -> dict[str, Any]:
-        """
-        Get albums for an artist from Spotify.
-
-        Args:
-            artist_id: Spotify artist ID
-            limit: Maximum albums per request (max 50)
-            include_groups: Album types - album, single, appears_on, compilation
-            fetch_all: If True, paginate to get all albums (no limit)
-
-        Returns:
-            Dict with success, albums list (id, name, release_date, total_tracks, etc.) or error info
-        """
-        if self.discography_source == "scraper":
-            cache_key = self._get_artist_albums_cache_key(artist_id)
-            if self.cache_enabled and self.cache and fetch_all:
-                cached = self.cache.get(cache_key, "spotify")
-                if cached is not None:
-                    self.logger.debug(f"Cache hit for Spotify scraper albums: {artist_id}")
-                    return {"success": True, "albums": cached}
-            result = await self._run_scraper(
-                _scraper_get_artist_albums,
-                artist_id,
-                include_groups,
-                fetch_all,
-                limit,
-            )
-            if (
-                result.get("success")
-                and self.cache_enabled
-                and self.cache
-                and fetch_all
-                and result.get("albums") is not None
-            ):
-                ttl = getattr(self.config, "NEW_RELEASES_CACHE_DAYS", 14)
-                self.cache.set(cache_key, "spotify", result["albums"], ttl)
-            return result
         try:
-            cache_key = self._get_artist_albums_cache_key(artist_id)
-            if self.cache_enabled and self.cache and fetch_all:
-                cached = self.cache.get(cache_key, "spotify")
-                if cached is not None:
-                    self.logger.debug(f"Cache hit for Spotify albums: {artist_id}")
-                    return {"success": True, "albums": cached}
-
             all_albums = []
             offset = 0
             page_limit = min(limit, 50)
@@ -989,6 +1019,8 @@ class SpotifyClient(BaseAPIClient):
                 result = await self._get(f"/artists/{artist_id}/albums", params=params)
 
                 if not result:
+                    if offset == 0:
+                        return {"success": False, "error": "No response", "albums": []}
                     break
 
                 items = result.get("items", [])
@@ -1016,44 +1048,121 @@ class SpotifyClient(BaseAPIClient):
                 if offset >= 200:  # Spotify caps at 200 albums per artist
                     break
 
-            if self.cache_enabled and self.cache and fetch_all:
-                ttl = getattr(self.config, "NEW_RELEASES_CACHE_DAYS", 14)
-                self.cache.set(cache_key, "spotify", all_albums, ttl)
-
             return {"success": True, "albums": all_albums}
 
         except Exception as e:
             self.logger.error(f"Error getting albums for artist {artist_id}: {e}")
             return {"success": False, "error": str(e), "albums": []}
 
+    async def get_artist_albums(
+        self,
+        artist_id: str,
+        limit: int = 50,
+        include_groups: str = "album,single,compilation,appears_on",
+        fetch_all: bool = False,
+    ) -> dict[str, Any]:
+        """
+        Get albums for an artist from Spotify.
+
+        Args:
+            artist_id: Spotify artist ID
+            limit: Maximum albums per request (max 50)
+            include_groups: Album types - album, single, appears_on, compilation
+            fetch_all: If True, paginate to get all albums (no limit)
+
+        Returns:
+            Dict with success, albums list, optional via (api|scraper), or error info
+        """
+        via = "api" if await self._can_try_api() else "scraper"
+        cache_key = self._get_artist_albums_cache_key(artist_id, via)
+        if self.cache_enabled and self.cache and fetch_all:
+            cached = self.cache.get(cache_key, "spotify")
+            if cached is not None:
+                self.logger.debug(f"Cache hit for Spotify {via} albums: {artist_id}")
+                return {"success": True, "albums": cached, "via": via}
+
+        result = await self._api_or_scraper(
+            "get_artist_albums",
+            lambda: self._get_artist_albums_api(artist_id, limit, include_groups, fetch_all),
+            lambda: self._run_scraper(
+                _scraper_get_artist_albums,
+                artist_id,
+                include_groups,
+                fetch_all,
+                limit,
+            ),
+            tag_via=True,
+        )
+
+        if (
+            result.get("success")
+            and self.cache_enabled
+            and self.cache
+            and fetch_all
+            and result.get("albums") is not None
+        ):
+            result_via = result.get("via", via)
+            ck = self._get_artist_albums_cache_key(artist_id, result_via)
+            ttl = getattr(self.config, "NEW_RELEASES_CACHE_DAYS", 14)
+            self.cache.set(ck, "spotify", result["albums"], ttl)
+
+        return result
+
+    async def _test_scraper_connection(self) -> bool:
+        scraper_result = await self._get_playlist_via_scraper(
+            "https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M"
+        )
+        return bool(scraper_result.get("success"))
+
     async def test_connection(self) -> bool:
-        """Test connection: API when credentials configured, scraper when not."""
+        """Test connection: API when credentials configured; scraper as fallback."""
+        detail = await self.test_connection_detail()
+        return detail.get("success", False)
+
+    async def test_connection_detail(self) -> dict[str, Any]:
+        """Test Spotify connectivity; returns success flag and human-readable message."""
+        api_ok = False
+        scraper_ok = False
         try:
             if self._has_credentials():
                 self.logger.info("Testing connection to Spotify API...")
-                if not await self._ensure_valid_token():
-                    self.logger.error("Failed to obtain Spotify access token")
-                    return False
-                result = await self._get("/tracks/4iV5W9uYEdYUVa79Axb7Rh")
-                if result:
-                    self.logger.info("Successfully connected to Spotify API")
-                    return True
-                self.logger.error("Spotify API test failed - no valid response")
-                return False
+                if await self._can_try_api():
+                    result = await self._get("/tracks/4iV5W9uYEdYUVa79Axb7Rh")
+                    api_ok = bool(result)
+                    if api_ok:
+                        self.logger.info("Successfully connected to Spotify API")
+                if not api_ok:
+                    self.logger.info("Spotify API test failed — trying scraper fallback")
+            else:
+                self.logger.info("Testing Spotify scraper (no API credentials)...")
 
-            self.logger.info("Testing Spotify scraper (no credentials)...")
-            scraper_result = await self._get_playlist_via_scraper(
-                "https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M"
-            )
-            if scraper_result.get("success"):
+            scraper_ok = await self._test_scraper_connection()
+            if scraper_ok:
                 self.logger.info("Spotify scraper test passed")
-                return True
-            self.logger.error(f"Spotify scraper test failed: {scraper_result.get('error')}")
-            return False
+
+            if api_ok:
+                return {"success": True, "message": "Official API connected", "mode": "api"}
+            if scraper_ok:
+                if self._has_credentials():
+                    return {
+                        "success": True,
+                        "message": "API failed; scraper connected",
+                        "mode": "scraper",
+                    }
+                return {
+                    "success": True,
+                    "message": "Scraper connected (no API creds)",
+                    "mode": "scraper",
+                }
+            return {
+                "success": False,
+                "message": "Both API and scraper failed",
+                "mode": None,
+            }
 
         except Exception as e:
             self.logger.error(f"Failed to connect to Spotify: {e}")
-            return False
+            return {"success": False, "message": "Connection test failed", "mode": None}
         finally:
             if self.session:
                 await self.session.close()

--- a/clients/client_spotify.py
+++ b/clients/client_spotify.py
@@ -566,7 +566,9 @@ class SpotifyClient(BaseAPIClient):
         loop = asyncio.get_event_loop()
         return await loop.run_in_executor(None, lambda: func(*args, **kwargs))
 
-    async def _enrich_nrd_album_api(self, album_id: str, fallback_artist_id: str | None) -> dict[str, Any]:
+    async def _enrich_nrd_album_api(
+        self, album_id: str, fallback_artist_id: str | None
+    ) -> dict[str, Any]:
         result = await self._get(f"/albums/{album_id}")
         if not result:
             return {"success": False, "album": None}
@@ -601,9 +603,7 @@ class SpotifyClient(BaseAPIClient):
             return await self._enrich_nrd_album_api(album_id, fallback_artist_id)
 
         async def scraper_fn():
-            return await self._run_scraper(
-                _scraper_enrich_nrd_album, album_id, fallback_artist_id
-            )
+            return await self._run_scraper(_scraper_enrich_nrd_album, album_id, fallback_artist_id)
 
         result = await self._api_or_scraper("enrich_nrd_album", api_fn, scraper_fn)
         if result.get("success") and result.get("album"):

--- a/commands/new_releases_discovery.py
+++ b/commands/new_releases_discovery.py
@@ -35,7 +35,7 @@ from database.config_models import (
 )
 from database.database import get_database_manager
 from utils.nrd_release_source import (
-    enrich_scraper_nrd_album,
+    enrich_nrd_album_if_needed,
     normalize_nrd_source,
     nrd_lidarr_artist_id_key,
     nrd_mb_streaming_provider,
@@ -167,12 +167,6 @@ class NewReleasesDiscoveryCommand(BaseCommand):
                 selected_types = self._get_album_types()
 
             source_provider = self._get_new_releases_source()
-            if normalize_nrd_source(source_provider) == "spotify":
-                if not config.SPOTIFY_CLIENT_ID or not config.SPOTIFY_CLIENT_SECRET:
-                    self.logger.error(
-                        "Spotify credentials not configured (new_releases_source=spotify)"
-                    )
-                    return False
             if not config.LIDARR_API_KEY or not config.LIDARR_URL:
                 self.logger.error("Lidarr not configured")
                 return False
@@ -316,12 +310,10 @@ class NewReleasesDiscoveryCommand(BaseCommand):
 
                                 had_pending = False
                                 candidates = []
-                                scraper_source = (
-                                    normalize_nrd_source(source_provider) == "spotify_scraper"
-                                )
+                                via_scraper = albums_result.get("via") == "scraper"
                                 for album in albums_result["albums"]:
                                     if (
-                                        not scraper_source
+                                        not via_scraper
                                         and album.get("primary_artist_id") != artist_id
                                     ):
                                         continue
@@ -336,7 +328,7 @@ class NewReleasesDiscoveryCommand(BaseCommand):
                                     if _title_matches_mb(album.get("name", ""), mb_titles):
                                         continue
 
-                                    album = await enrich_scraper_nrd_album(
+                                    album = await enrich_nrd_album_if_needed(
                                         release_client, album, source_provider
                                     )
                                     if album.get("primary_artist_id") != artist_id:
@@ -455,7 +447,7 @@ class NewReleasesDiscoveryCommand(BaseCommand):
         return {"album"}
 
     def _get_new_releases_source(self) -> str:
-        """Get new releases source: deezer, spotify_scraper, or legacy spotify (default deezer)."""
+        """Get new releases source: deezer or spotify (default deezer)."""
         cfg = getattr(self, "config_json", None) or {}
         return normalize_nrd_source(cfg.get("new_releases_source"))
 

--- a/frontend/src/command-spec/copy.ts
+++ b/frontend/src/command-spec/copy.ts
@@ -78,9 +78,9 @@ export const commandUiCopy = {
     releaseTypesHeading: "Release types to include",
     releaseTypesHelp: "Used for batch runs and ad-hoc artist scans",
     sourceHelp:
-      "Deezer uses public data. Spotify uses public catalog scraping—no account required.",
+      "Deezer uses open API. Spotify defaults to spotifyscraper unless valid client creds are configured, in which case the official API is used.",
     deezerOption: "Deezer",
-    spotifyOption: "Spotify (no account required)",
+    spotifyOption: "Spotify",
   },
   artistEvents: {
     artistsPerRun: "Artists per scheduled run",

--- a/frontend/src/components/command-edit/sections/NewReleasesDiscoverySection.tsx
+++ b/frontend/src/components/command-edit/sections/NewReleasesDiscoverySection.tsx
@@ -5,16 +5,16 @@ import { commandUiCopy } from "@/command-spec";
 
 const nr = commandUiCopy.newReleases;
 
+function normalizeNrdSourceValue(src: string | undefined): "deezer" | "spotify" {
+  if (src === "spotify" || src === "spotify_scraper") return "spotify";
+  return "deezer";
+}
+
 export function NewReleasesDiscoverySection({ ctx }: { ctx: CommandEditRenderContext }) {
   const { editForm, setEditForm, nrdSources } = ctx;
-  const spotifyScraper = nrdSources.find((s) => s.id === "spotify_scraper");
-  const spotifyConfigured = spotifyScraper?.configured !== false;
-  const sourceValue =
-    editForm.new_releases_source === "spotify_scraper"
-      ? "spotify_scraper"
-      : editForm.new_releases_source === "spotify"
-        ? "spotify_scraper"
-        : "deezer";
+  const spotifySource = nrdSources.find((s) => s.id === "spotify");
+  const spotifyConfigured = spotifySource?.configured !== false;
+  const sourceValue = normalizeNrdSourceValue(editForm.new_releases_source);
 
   return (
     <>
@@ -38,16 +38,15 @@ export function NewReleasesDiscoverySection({ ctx }: { ctx: CommandEditRenderCon
           onChange={(e) =>
             setEditForm((f) => ({
               ...f,
-              new_releases_source:
-                e.target.value === "spotify_scraper" ? "spotify_scraper" : "deezer",
+              new_releases_source: e.target.value === "spotify" ? "spotify" : "deezer",
             }))
           }
           className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm"
         >
           <option value="deezer">{nr.deezerOption}</option>
-          <option value="spotify_scraper" disabled={!!spotifyScraper && !spotifyConfigured}>
+          <option value="spotify" disabled={!!spotifySource && !spotifyConfigured}>
             {nr.spotifyOption}
-            {spotifyScraper && !spotifyConfigured ? " (unavailable)" : ""}
+            {spotifySource && !spotifyConfigured ? " (unavailable)" : ""}
           </option>
         </select>
         <p className="text-xs text-muted-foreground">{nr.sourceHelp}</p>

--- a/frontend/src/components/command-edit/types.ts
+++ b/frontend/src/components/command-edit/types.ts
@@ -9,7 +9,7 @@ export type CommandEditFormState = {
   /** artist_events_refresh: days between per-artist fetches */
   refresh_ttl_days?: number;
   album_types?: string[];
-  new_releases_source?: "spotify" | "spotify_scraper" | "deezer";
+  new_releases_source?: "spotify" | "deezer";
   artists_to_query?: number;
   similar_per_artist?: number;
   artist_cooldown_days?: number;

--- a/frontend/src/pages/Commands.tsx
+++ b/frontend/src/pages/Commands.tsx
@@ -256,8 +256,7 @@ export function CommandsPage() {
     if (
       editingCommand?.command_name === "new_releases_discovery" &&
       nrdSources.length > 0 &&
-      (editForm.new_releases_source === "spotify" ||
-        editForm.new_releases_source === "spotify_scraper")
+      editForm.new_releases_source === "spotify"
     ) {
       const spotifySrc = nrdSources.find((s) => s.id === "spotify");
       if (spotifySrc && !spotifySrc.configured) {
@@ -373,8 +372,7 @@ export function CommandsPage() {
     const cfg = command.config_json || {};
     const typesStr = (cfg.album_types as string) || "album";
     const src = (cfg.new_releases_source as string) || "deezer";
-    const nrdSource =
-      src === "spotify_scraper" || src === "spotify" ? "spotify" : "deezer";
+    const nrdSource = src === "spotify_scraper" || src === "spotify" ? "spotify" : "deezer";
     const isDaylist = command.command_name.startsWith("daylist_");
 
     const timePeriods: Record<string, { start: number; end: number }> = {

--- a/frontend/src/pages/Commands.tsx
+++ b/frontend/src/pages/Commands.tsx
@@ -256,10 +256,11 @@ export function CommandsPage() {
     if (
       editingCommand?.command_name === "new_releases_discovery" &&
       nrdSources.length > 0 &&
-      editForm.new_releases_source === "spotify_scraper"
+      (editForm.new_releases_source === "spotify" ||
+        editForm.new_releases_source === "spotify_scraper")
     ) {
-      const scraperSrc = nrdSources.find((s) => s.id === "spotify_scraper");
-      if (scraperSrc && !scraperSrc.configured) {
+      const spotifySrc = nrdSources.find((s) => s.id === "spotify");
+      if (spotifySrc && !spotifySrc.configured) {
         setEditForm((f) => ({ ...f, new_releases_source: "deezer" }));
       }
     }
@@ -372,7 +373,8 @@ export function CommandsPage() {
     const cfg = command.config_json || {};
     const typesStr = (cfg.album_types as string) || "album";
     const src = (cfg.new_releases_source as string) || "deezer";
-    const nrdSource = src === "spotify_scraper" || src === "spotify" ? "spotify_scraper" : "deezer";
+    const nrdSource =
+      src === "spotify_scraper" || src === "spotify" ? "spotify" : "deezer";
     const isDaylist = command.command_name.startsWith("daylist_");
 
     const timePeriods: Record<string, { start: number; end: number }> = {

--- a/readme-extended.md
+++ b/readme-extended.md
@@ -128,8 +128,8 @@ The job fails if CRITICAL/HIGH are found; the image is not pushed until the scan
 **Access**: Web UI → New Releases (`/new-releases`)
 
 **Benefits**:
-- **Deezer (default)**: No account required—uses public API
-- **Spotify (optional)**: No account required—uses public catalog scraping via spotifyscraper; alternative when Deezer attaches wrong albums to an artist page (catalog pollution)
+- **Deezer (default)**: Uses open API; no account required
+- **Spotify (optional)**: Defaults to spotifyscraper (no account required). When valid Spotify Client ID/Secret are configured and the API works, the official API is used instead—useful when Deezer attaches wrong albums to an artist page (catalog pollution)
 
 - Uses Lidarr artist links when available (avoids name collisions like Emmure vs emmurée)
 - 1 MusicBrainz API call per artist (release groups), no per-album lookups
@@ -138,9 +138,9 @@ The job fails if CRITICAL/HIGH are found; the image is not pushed until the scan
 - **Scan Artist by URL**: Artist not in Lidarr yet? Paste a Spotify or Deezer artist URL to fetch all albums, compare to MusicBrainz, and get a list of missing releases with Harmony links; add each in Harmony, then add the artist to Lidarr after ~24h
 
 **Requirements**: Lidarr; MusicBrainz enabled for batch scans  
-**Configuration**: Release source (Deezer or Spotify) in Commands → Edit; `NEW_RELEASES_CACHE_DAYS` (default 14) in Configuration → Music Sources
+**Configuration**: Release source (Deezer or Spotify) in Commands → Edit; optional Spotify Client ID/Secret in Configuration → Music Sources; `NEW_RELEASES_CACHE_DAYS` (default 14)
 
-**Note**: Legacy `spotify` API source may still exist in older configs but is not exposed in the UI. Spotify scraper is the recommended credential-free Spotify path.
+**Note**: Older configs may store `spotify_scraper` as the release source; it is treated as Spotify automatically.
 
 ### Playlist Generators (Plex/Jellyfin)
 
@@ -206,7 +206,7 @@ With Library Cache:    1 library fetch + instant memory searches = ~30 seconds
 - **Plex Token**: Get from [Plex Support Guide](https://support.plex.tv/articles/204059436/) (for playlist sync)
 - **Jellyfin Token**: Get from [Jellyfin API Documentation](https://jellyfin.org/docs/general/administration/access-tokens/) (for playlist sync)
 - **Jellyfin User ID**: Found in Jellyfin Dashboard → Users → Select User → User ID
-- **Spotify Client ID & Secret**: Get from [Spotify Developer Dashboard](https://developer.spotify.com/dashboard) (for playlist sync, public playlists only)
+- **Spotify Client ID & Secret** (optional): Get from [Spotify Developer Dashboard](https://developer.spotify.com/dashboard). Enables official API for playlist sync and NRD when valid; spotifyscraper is used otherwise.
 
 ### Event Sources (artist events)
 

--- a/services/config_service.py
+++ b/services/config_service.py
@@ -324,7 +324,7 @@ class ConfigService:
                 "default_value": "",
                 "data_type": "string",
                 "category": "spotify",
-                "description": "Spotify API Client ID (public playlists, New Releases)",
+                "description": "Spotify API Client ID (optional; enables official API for playlists and NRD)",
                 "is_sensitive": True,
             },
             {
@@ -332,7 +332,7 @@ class ConfigService:
                 "default_value": "",
                 "data_type": "string",
                 "category": "spotify",
-                "description": "Spotify API Client Secret (public playlists, New Releases)",
+                "description": "Spotify API Client Secret (optional; spotifyscraper used when not set or API unavailable)",
                 "is_sensitive": True,
             },
             {

--- a/tests/test_nrd_spotify_scraper.py
+++ b/tests/test_nrd_spotify_scraper.py
@@ -1,10 +1,11 @@
-"""Tests for NRD spotify_scraper source routing."""
+"""Tests for NRD Spotify source routing and unified client behavior."""
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from utils.nrd_release_source import (
+    enrich_nrd_album_if_needed,
     normalize_nrd_source,
     nrd_lidarr_artist_id_key,
     nrd_mb_streaming_provider,
@@ -16,7 +17,7 @@ from utils.nrd_release_source import (
 def test_normalize_nrd_source_defaults_and_aliases():
     assert normalize_nrd_source(None) == "deezer"
     assert normalize_nrd_source("deezer") == "deezer"
-    assert normalize_nrd_source("spotify_scraper") == "spotify_scraper"
+    assert normalize_nrd_source("spotify_scraper") == "spotify"
     assert normalize_nrd_source("spotify") == "spotify"
     assert normalize_nrd_source("unknown") == "deezer"
 
@@ -38,11 +39,11 @@ def test_nrd_lidarr_artist_id_key():
     assert nrd_lidarr_artist_id_key("spotify_scraper") == "spotifyArtistId"
 
 
-def test_nrd_release_client_routes_to_scraper():
+def test_nrd_release_client_routes_to_spotify():
     config = MagicMock()
     with patch("clients.client_spotify.SpotifyClient") as mock_spotify:
         nrd_release_client("spotify_scraper", config)
-        mock_spotify.assert_called_once_with(config, discography_source="scraper")
+        mock_spotify.assert_called_once_with(config)
 
 
 def test_nrd_release_client_routes_to_deezer():
@@ -52,20 +53,22 @@ def test_nrd_release_client_routes_to_deezer():
         mock_deezer.assert_called_once_with(config)
 
 
-def test_nrd_release_client_legacy_spotify_api():
+def test_nrd_release_client_spotify_unified():
     config = MagicMock()
     with patch("clients.client_spotify.SpotifyClient") as mock_spotify:
         nrd_release_client("spotify", config)
-        mock_spotify.assert_called_once_with(config, discography_source="api")
+        mock_spotify.assert_called_once_with(config)
 
 
 @pytest.mark.asyncio
-async def test_spotify_client_scraper_get_artist_albums():
+async def test_spotify_client_get_artist_albums_uses_scraper_without_creds():
     from clients.client_spotify import SpotifyClient
 
     config = MagicMock()
+    config.SPOTIFY_CLIENT_ID = ""
+    config.SPOTIFY_CLIENT_SECRET = ""
     config.NEW_RELEASES_CACHE_DAYS = 14
-    client = SpotifyClient(config, discography_source="scraper")
+    client = SpotifyClient(config)
     client.cache_enabled = False
 
     mock_albums = {
@@ -75,15 +78,47 @@ async def test_spotify_client_scraper_get_artist_albums():
     with patch.object(client, "_run_scraper", new=AsyncMock(return_value=mock_albums)):
         result = await client.get_artist_albums("art1", fetch_all=True)
     assert result["success"] is True
+    assert result["via"] == "scraper"
     assert len(result["albums"]) == 1
 
 
 @pytest.mark.asyncio
-async def test_enrich_nrd_album_scraper_mode():
+async def test_spotify_client_get_artist_albums_api_fallback_to_scraper():
     from clients.client_spotify import SpotifyClient
 
     config = MagicMock()
-    client = SpotifyClient(config, discography_source="scraper")
+    config.SPOTIFY_CLIENT_ID = "id"
+    config.SPOTIFY_CLIENT_SECRET = "secret"
+    config.NEW_RELEASES_CACHE_DAYS = 14
+    client = SpotifyClient(config)
+    client.cache_enabled = False
+
+    scraper_result = {
+        "success": True,
+        "albums": [{"id": "a1", "name": "Album", "primary_artist_id": "art1"}],
+    }
+    with (
+        patch.object(client, "_can_try_api", new=AsyncMock(return_value=True)),
+        patch.object(
+            client,
+            "_get_artist_albums_api",
+            new=AsyncMock(return_value={"success": False, "error": "fail", "albums": []}),
+        ),
+        patch.object(client, "_run_scraper", new=AsyncMock(return_value=scraper_result)),
+    ):
+        result = await client.get_artist_albums("art1", fetch_all=True)
+    assert result["success"] is True
+    assert result["via"] == "scraper"
+
+
+@pytest.mark.asyncio
+async def test_enrich_nrd_album_scraper_fallback():
+    from clients.client_spotify import SpotifyClient
+
+    config = MagicMock()
+    config.SPOTIFY_CLIENT_ID = ""
+    config.SPOTIFY_CLIENT_SECRET = ""
+    client = SpotifyClient(config)
     disc_album = {"id": "a1", "name": "Disc", "primary_artist_id": "art1"}
     enriched = {"id": "a1", "name": "Full", "primary_artist_id": "art1", "spotify_url": "http://x"}
     with patch.object(
@@ -94,19 +129,49 @@ async def test_enrich_nrd_album_scraper_mode():
 
 
 @pytest.mark.asyncio
-async def test_enrich_scraper_nrd_album_skips_deezer():
-    from utils.nrd_release_source import enrich_scraper_nrd_album
-
+async def test_enrich_nrd_album_if_needed_skips_deezer():
     album = {"id": "1", "name": "A"}
     client = MagicMock()
-    result = await enrich_scraper_nrd_album(client, album, "deezer")
+    result = await enrich_nrd_album_if_needed(client, album, "deezer")
     assert result is album
     client.enrich_nrd_album.assert_not_called()
 
 
-def test_new_releases_discovery_source_accepts_spotify_scraper():
+@pytest.mark.asyncio
+async def test_test_connection_detail_scraper_when_no_creds():
+    from clients.client_spotify import SpotifyClient
+
+    config = MagicMock()
+    config.SPOTIFY_CLIENT_ID = ""
+    config.SPOTIFY_CLIENT_SECRET = ""
+    client = SpotifyClient(config)
+    with patch.object(client, "_test_scraper_connection", new=AsyncMock(return_value=True)):
+        detail = await client.test_connection_detail()
+    assert detail["success"] is True
+    assert detail["mode"] == "scraper"
+
+
+@pytest.mark.asyncio
+async def test_test_connection_detail_api_failed_scraper_ok():
+    from clients.client_spotify import SpotifyClient
+
+    config = MagicMock()
+    config.SPOTIFY_CLIENT_ID = "id"
+    config.SPOTIFY_CLIENT_SECRET = "secret"
+    client = SpotifyClient(config)
+    with (
+        patch.object(client, "_can_try_api", new=AsyncMock(return_value=True)),
+        patch.object(client, "_get", new=AsyncMock(return_value=None)),
+        patch.object(client, "_test_scraper_connection", new=AsyncMock(return_value=True)),
+    ):
+        detail = await client.test_connection_detail()
+    assert detail["success"] is True
+    assert detail["message"] == "API failed; scraper connected"
+
+
+def test_new_releases_discovery_source_normalizes_spotify_scraper():
     from commands.new_releases_discovery import NewReleasesDiscoveryCommand
 
     cmd = NewReleasesDiscoveryCommand()
     cmd.config_json = {"new_releases_source": "spotify_scraper"}
-    assert cmd._get_new_releases_source() == "spotify_scraper"
+    assert cmd._get_new_releases_source() == "spotify"

--- a/utils/nrd_release_source.py
+++ b/utils/nrd_release_source.py
@@ -7,18 +7,20 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from clients.client_base import BaseAPIClient
 
-VALID_NRD_SOURCES = frozenset({"deezer", "spotify_scraper", "spotify"})
+VALID_NRD_SOURCES = frozenset({"deezer", "spotify"})
 
 
 def normalize_nrd_source(src: str | None) -> str:
     s = (src or "deezer").strip().lower()
+    if s in ("spotify", "spotify_scraper"):
+        return "spotify"
     if s in VALID_NRD_SOURCES:
         return s
     return "deezer"
 
 
 def nrd_uses_spotify(source: str) -> bool:
-    return normalize_nrd_source(source) in ("spotify", "spotify_scraper")
+    return normalize_nrd_source(source) == "spotify"
 
 
 def nrd_mb_streaming_provider(source: str) -> str:
@@ -36,14 +38,12 @@ def nrd_release_client(source: str, config) -> BaseAPIClient:
     src = normalize_nrd_source(source)
     if src == "deezer":
         return DeezerClient(config)
-    if src == "spotify_scraper":
-        return SpotifyClient(config, discography_source="scraper")
-    return SpotifyClient(config, discography_source="api")
+    return SpotifyClient(config)
 
 
-async def enrich_scraper_nrd_album(release_client, album: dict, source: str) -> dict:
-    """Call get_album for a discography candidate when using spotify_scraper."""
-    if normalize_nrd_source(source) != "spotify_scraper":
+async def enrich_nrd_album_if_needed(release_client, album: dict, source: str) -> dict:
+    """Enrich discography candidate with full album metadata when using Spotify."""
+    if not nrd_uses_spotify(source):
         return album
     enrich = getattr(release_client, "enrich_nrd_album", None)
     if enrich is None:


### PR DESCRIPTION
API-first when Client ID/Secret work; spotifyscraper used otherwise for playlist sync, NRD, and scan-by-URL. NRD picker is Deezer or Spotify only.