### PR TITLE
Auto-expand Arr sidebar sections from the active route.

### DIFF
--- a/frontend/src/arr/arr-tokens.css
+++ b/frontend/src/arr/arr-tokens.css
@@ -100,26 +100,6 @@
   border-left: 1px solid color-mix(in oklch, var(--arr-accent) 40%, var(--arr-sidebar-border));
 }
 
-.arr-shell[data-ui-shell="arr"] .arr-sidebar-chevron {
-  display: inline-flex;
-  height: 2rem;
-  width: 2rem;
-  shrink: 0;
-  align-items: center;
-  justify-content: center;
-  border-radius: 0.375rem;
-  color: var(--arr-sidebar-text-muted);
-  transition:
-    background-color 0.15s,
-    color 0.15s,
-    transform 0.15s;
-}
-
-.arr-shell[data-ui-shell="arr"] .arr-sidebar-chevron:hover {
-  background: color-mix(in oklch, var(--arr-sidebar-active-bg) 70%, transparent);
-  color: var(--arr-sidebar-text);
-}
-
 .arr-shell[data-ui-shell="arr"] .arr-section-label {
   padding: 0.75rem 0.625rem 0.375rem;
   font-size: 0.6875rem;

--- a/frontend/src/arr/components/ArrSidebar.tsx
+++ b/frontend/src/arr/components/ArrSidebar.tsx
@@ -36,10 +36,7 @@ function CollapsibleNavSection({ section }: { section: ArrNavSection }) {
           to={section.indexPath}
           end={section.indexEnd}
           className={({ isActive }) =>
-            cn(
-              "arr-sidebar-link",
-              (isActive || isInSection) && "arr-sidebar-section-title-active"
-            )
+            cn("arr-sidebar-link", (isActive || isInSection) && "arr-sidebar-section-title-active")
           }
         >
           <section.icon className="h-4 w-4 shrink-0 opacity-80" aria-hidden />

--- a/frontend/src/arr/components/ArrSidebar.tsx
+++ b/frontend/src/arr/components/ArrSidebar.tsx
@@ -1,6 +1,4 @@
 import { NavLink, useLocation, useNavigate } from "react-router-dom";
-import { ChevronDown } from "lucide-react";
-import { useEffect, useState } from "react";
 import { arrNavSections, arrPrimaryNav, type ArrNavLink, type ArrNavSection } from "@/arr/arr-nav";
 import { useAppVersion } from "@/hooks/useAppVersion";
 import { cn } from "@/lib/utils";
@@ -18,14 +16,9 @@ function CollapsibleNavSection({ section }: { section: ArrNavSection }) {
   const location = useLocation();
   const navigate = useNavigate();
   const isInSection = location.pathname.startsWith(section.pathPrefix);
-  const [expanded, setExpanded] = useState(isInSection);
-
-  useEffect(() => {
-    if (isInSection) setExpanded(true);
-  }, [isInSection]);
+  const expanded = isInSection;
 
   const openSection = () => {
-    setExpanded(true);
     if (isInSection) return;
     if (section.indexPath) {
       navigate(section.indexPath);
@@ -38,46 +31,33 @@ function CollapsibleNavSection({ section }: { section: ArrNavSection }) {
 
   return (
     <div className={cn("arr-sidebar-section pt-1", isInSection && "is-active")}>
-      <div className="flex items-center gap-0.5 pr-1">
-        {section.indexPath ? (
-          <NavLink
-            to={section.indexPath}
-            end={section.indexEnd}
-            className={({ isActive }) =>
-              cn(
-                "arr-sidebar-link min-w-0 flex-1",
-                (isActive || isInSection) && "arr-sidebar-section-title-active"
-              )
-            }
-          >
-            <section.icon className="h-4 w-4 shrink-0 opacity-80" aria-hidden />
-            <span className="truncate">{section.label}</span>
-          </NavLink>
-        ) : (
-          <button
-            type="button"
-            className={cn(
-              "arr-sidebar-link min-w-0 flex-1 text-left",
-              isInSection && "arr-sidebar-section-title-active"
-            )}
-            onClick={openSection}
-          >
-            <section.icon className="h-4 w-4 shrink-0 opacity-80" aria-hidden />
-            <span className="truncate">{section.label}</span>
-          </button>
-        )}
-        {section.items.length > 0 ? (
-          <button
-            type="button"
-            className="arr-sidebar-chevron"
-            onClick={() => setExpanded((value) => !value)}
-            aria-expanded={expanded}
-            aria-label={expanded ? `Collapse ${section.label}` : `Expand ${section.label}`}
-          >
-            <ChevronDown className={cn("h-4 w-4 transition-transform", expanded && "rotate-180")} />
-          </button>
-        ) : null}
-      </div>
+      {section.indexPath ? (
+        <NavLink
+          to={section.indexPath}
+          end={section.indexEnd}
+          className={({ isActive }) =>
+            cn(
+              "arr-sidebar-link",
+              (isActive || isInSection) && "arr-sidebar-section-title-active"
+            )
+          }
+        >
+          <section.icon className="h-4 w-4 shrink-0 opacity-80" aria-hidden />
+          <span className="truncate">{section.label}</span>
+        </NavLink>
+      ) : (
+        <button
+          type="button"
+          className={cn(
+            "arr-sidebar-link w-full text-left",
+            isInSection && "arr-sidebar-section-title-active"
+          )}
+          onClick={openSection}
+        >
+          <section.icon className="h-4 w-4 shrink-0 opacity-80" aria-hidden />
+          <span className="truncate">{section.label}</span>
+        </button>
+      )}
       {expanded && section.items.length > 0 ? (
         <div className="arr-sidebar-section-nested space-y-0.5 pt-0.5">
           {section.items.map((item) => (


### PR DESCRIPTION
Remove manual chevron toggles so Commands, Settings, and System collapse when navigating away, matching Lidarr-style navigation.