### PR TITLE
Fix login by registering auth API routes before SPA catch-all.

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -306,25 +306,6 @@ async def lifespan(app: FastAPI):
     # Initialize session store for auth
     app.state.sessions = {}
 
-    # Import and include commands router after logging is configured
-    try:
-        from app.api import commands
-
-        app.include_router(commands.router, prefix="/api/commands", tags=["commands"])
-        get_app_logger().info("Commands API router loaded successfully")
-    except Exception as e:
-        get_app_logger().error(f"Failed to load commands API router: {e}")
-        # Don't raise here as other APIs still work
-
-    try:
-        from app.api import auth_routes
-
-        app.include_router(auth_routes.router, prefix="/api/auth", tags=["auth"])
-        get_app_logger().info("Auth API router loaded successfully")
-    except Exception as e:
-        get_app_logger().error(f"Failed to load auth API router: {e}")
-        # Don't raise here as other APIs still work
-
     yield
 
     # Shutdown
@@ -659,9 +640,20 @@ async def react_system(request: Request, full_path: str = ""):
 
 
 # API Routes - Import after logging is configured
-from app.api import config, events, import_lists, new_releases, status, test_connectivity
+from app.api import (
+    auth_routes,
+    commands,
+    config,
+    events,
+    import_lists,
+    new_releases,
+    status,
+    test_connectivity,
+)
 
-# Include API routers
+# Include API routers (must register before SPA catch-all so /api/* is not shadowed)
+app.include_router(auth_routes.router, prefix="/api/auth", tags=["auth"])
+app.include_router(commands.router, prefix="/api/commands", tags=["commands"])
 app.include_router(config.router, prefix="/api/config", tags=["configuration"])
 app.include_router(status.router, prefix="/api/status", tags=["status"])
 app.include_router(import_lists.router, prefix="/import_lists", tags=["import_lists"])

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -67,15 +67,21 @@ def test_api_and_import_list_paths_require_auth():
     assert _requires_auth("/import_lists/metrics") is True
 
 
-def test_auth_status_not_shadowed_by_spa_fallback():
-    from starlette.testclient import TestClient
+def test_api_auth_routes_registered_before_spa_catchall():
+    """Regression: SPA catch-all must not shadow /api/auth/* registered after it."""
+    from pathlib import Path
 
-    from app.main import app
+    main_source = (Path(__file__).resolve().parents[1] / "app" / "main.py").read_text()
+    auth_marker = 'app.include_router(auth_routes.router, prefix="/api/auth"'
+    commands_marker = 'app.include_router(commands.router, prefix="/api/commands"'
+    catchall_marker = "async def react_spa_fallback"
 
-    with TestClient(app) as client:
-        response = client.get("/api/auth/status")
+    assert auth_marker in main_source
+    assert commands_marker in main_source
+    assert catchall_marker in main_source
+    assert main_source.index(auth_marker) < main_source.index(catchall_marker)
+    assert main_source.index(commands_marker) < main_source.index(catchall_marker)
 
-    assert response.status_code == 200
-    payload = response.json()
-    assert "setup_required" in payload
-    assert "authenticated" in payload
+    lifespan_block = main_source.split("async def lifespan", 1)[1].split("\n\n    yield", 1)[0]
+    assert auth_marker not in lifespan_block
+    assert commands_marker not in lifespan_block

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -65,3 +65,17 @@ def test_api_and_import_list_paths_require_auth():
     assert _requires_auth("/api/auth/status") is False
     assert _requires_auth("/import_lists/discovery_lastfm") is False
     assert _requires_auth("/import_lists/metrics") is True
+
+
+def test_auth_status_not_shadowed_by_spa_fallback():
+    from starlette.testclient import TestClient
+
+    from app.main import app
+
+    with TestClient(app) as client:
+        response = client.get("/api/auth/status")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert "setup_required" in payload
+    assert "authenticated" in payload


### PR DESCRIPTION
The SPA fallback matched /api/* paths before lifespan-registered routers, so /api/auth/status returned 404 and AuthGuard never left loading.