### PR TITLE
Raise utils test coverage to 73% and enforce a 70% CI floor.

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -54,7 +54,7 @@ jobs:
           pip install -r requirements-dev.txt
 
       - name: Run unit tests
-        run: pytest tests/ -v --cov=utils --cov=tests --cov-report=term-missing
+        run: pytest tests/ -v --cov=utils --cov=tests --cov-report=term-missing --cov-fail-under=70
 
   frontend-lint:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.17-dev] - TBD
+## [0.3.17] - 2026-06-25
 
 ### Features
-- **Spotify Client Update**: Supports Spotify credentials (client ID/secret), but if they don't validate or not configured, defaults to use spotifyscraper for all functions for Spotify (New Release Discovery, Playlist Sync, etc).
 - **Modern arr UI (preview)**: Optional Sonarr-style shell with sidebar navigation, collapsible Settings/System sections, and panel-based layouts on Commands, Import Lists, New Releases, Events, Settings, and System pages. Toggle from the header, upper-right.
+- **Spotify Client Update**: Supports Spotify credentials (client ID/secret), but if they don't validate or not configured, defaults to use spotifyscraper for all functions for Spotify (New Release Discovery, Playlist Sync, etc).
 
 ### Fixes
-- ???
+- **Minor fixes**: Playlist matching updates; minor bug fixes.
 
 ### Housekeeping
 - **Icons** - Generated icons for Cmdarr.
 - **Python Package Update**: Review and update of Python packages.
+- **Test coverage**: Added unit tests for timezone, event dedupe coalescing, and related utils; enforce 70% coverage floor in CI (current ~73%).
 
 ## [0.3.16] - 2026-06-22
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ check-zizmor:
 	uvx zizmor==$(ZIZMOR_VERSION) . --offline
 check-test test:
 	uv run --with-requirements requirements-dev.txt pytest tests/ -v \
-		--cov=utils --cov=tests --cov-report=term-missing
+		--cov=utils --cov=tests --cov-report=term-missing --cov-fail-under=70
 check-frontend:
 	cd frontend && npm run lint && npm run format:check
 check-frontend-typecheck:

--- a/__version__.py
+++ b/__version__.py
@@ -4,4 +4,4 @@ Cmdarr version information
 Bump only at release; during development use a -dev suffix (e.g. 0.3.14-dev).
 """
 
-__version__ = "0.3.17-dev"
+__version__ = "0.3.17"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,15 @@ ignore = [
 
 [tool.ruff.format]
 quote-style = "double"
+
+[tool.coverage.run]
+source = ["utils"]
+omit = [
+    "utils/cache_client_example.py",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+]

--- a/tests/test_event_dedupe_coalesce.py
+++ b/tests/test_event_dedupe_coalesce.py
@@ -1,0 +1,88 @@
+"""Tests for concert event dedupe coalescing."""
+
+import sqlite3
+
+from utils.event_dedupe_coalesce import (
+    coalesce_concert_event_duplicates,
+    normalize_concert_event_place_fields,
+)
+
+
+def _create_concert_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE concert_event (
+            id INTEGER PRIMARY KEY,
+            artist_mbid TEXT,
+            artist_name TEXT,
+            local_date TEXT,
+            venue_name TEXT,
+            venue_city TEXT,
+            venue_region TEXT,
+            venue_lat REAL,
+            venue_lon REAL,
+            dedupe_key TEXT,
+            user_interested INTEGER DEFAULT 0
+        );
+        CREATE TABLE concert_event_source (
+            id INTEGER PRIMARY KEY,
+            concert_event_id INTEGER,
+            provider TEXT,
+            external_id TEXT
+        );
+        """
+    )
+
+
+def test_coalesce_merges_duplicate_events_and_sources():
+    conn = sqlite3.connect(":memory:")
+    _create_concert_schema(conn)
+    cur = conn.cursor()
+    cur.executescript(
+        """
+        INSERT INTO concert_event VALUES
+          (1, 'mbid-a', 'Artist', '2026-09-18', 'Brooklyn Bowl', 'Nashville', 'TN',
+           36.16, -86.77, 'old-key-1', 0),
+          (2, 'mbid-a', 'Artist', '2026-09-18', 'Brooklyn Bowl', 'Nashville', NULL,
+           NULL, NULL, 'old-key-2', 1);
+        INSERT INTO concert_event_source VALUES
+          (1, 1, 'ticketmaster', 'tm-1'),
+          (2, 2, 'deezer', 'dz-1');
+        """
+    )
+
+    coalesce_concert_event_duplicates(cur)
+    conn.commit()
+
+    cur.execute("SELECT COUNT(*) FROM concert_event")
+    assert cur.fetchone()[0] == 1
+    cur.execute("SELECT user_interested, venue_lat, venue_region FROM concert_event")
+    interested, lat, region = cur.fetchone()
+    assert interested == 1
+    assert lat == 36.16
+    assert region == "TN"
+    cur.execute("SELECT provider FROM concert_event_source ORDER BY provider")
+    assert [row[0] for row in cur.fetchall()] == ["deezer", "ticketmaster"]
+    cur.execute("SELECT dedupe_key FROM concert_event")
+    assert cur.fetchone()[0]
+
+
+def test_normalize_concert_event_place_fields_splits_comma_city():
+    conn = sqlite3.connect(":memory:")
+    _create_concert_schema(conn)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        INSERT INTO concert_event (
+            artist_mbid, artist_name, local_date, venue_name, venue_city, venue_region
+        ) VALUES ('mbid', 'Artist', '2026-01-01', 'Venue', 'Nashville, TN', NULL)
+        """
+    )
+
+    normalize_concert_event_place_fields(cur)
+    conn.commit()
+
+    cur.execute("SELECT venue_city, venue_region FROM concert_event")
+    city, region = cur.fetchone()
+    assert city == "Nashville"
+    assert region == "TN"

--- a/tests/test_lidarr_artist_sync.py
+++ b/tests/test_lidarr_artist_sync.py
@@ -1,0 +1,39 @@
+"""Tests for Lidarr artist cache upsert."""
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+from utils.lidarr_artist_sync import upsert_lidarr_artists_from_payload
+
+
+def test_upsert_lidarr_artists_from_payload_insert_and_update():
+    session = MagicMock()
+    existing = MagicMock()
+    session.query.return_value.filter.return_value.first.side_effect = [None, existing]
+
+    now = datetime(2026, 3, 13, tzinfo=UTC)
+    inserted, updated = upsert_lidarr_artists_from_payload(
+        session,
+        [
+            {
+                "musicBrainzId": "mbid-new",
+                "artistName": "New Artist",
+                "id": 10,
+                "spotifyArtistId": "sp1",
+                "deezerArtistId": "dz1",
+            },
+            {
+                "musicBrainzId": "mbid-old",
+                "artistName": "Updated Artist",
+                "id": 11,
+            },
+            {"artistName": "No MBID"},
+        ],
+        now=now,
+    )
+
+    assert inserted == 1
+    assert updated == 1
+    session.add.assert_called_once()
+    assert existing.artist_name == "Updated Artist"
+    assert existing.last_synced_at == now

--- a/tests/test_plex_user.py
+++ b/tests/test_plex_user.py
@@ -1,0 +1,9 @@
+"""Tests for Plex account helper utilities."""
+
+from utils.plex_user import get_account_name
+
+
+def test_get_account_name_matches_id():
+    accounts = [{"id": "1", "name": "Admin"}, {"id": "2", "name": "Guest"}]
+    assert get_account_name(accounts, "2") == "Guest"
+    assert get_account_name(accounts, "9") == "9"

--- a/tests/test_spotify_playlist_detector.py
+++ b/tests/test_spotify_playlist_detector.py
@@ -1,0 +1,27 @@
+"""Tests for Spotify playlist ID classification."""
+
+from utils.spotify_playlist_detector import SpotifyPlaylistDetector
+
+
+def test_is_user_generated_playlist():
+    assert SpotifyPlaylistDetector.is_user_generated_playlist("37i9dQZF1EP6YuccBxUcC1") is True
+    assert SpotifyPlaylistDetector.is_user_generated_playlist("public-playlist-id") is False
+
+
+def test_get_playlist_info_known_and_generated():
+    daylist = SpotifyPlaylistDetector.get_playlist_info("37i9dQZF1EP6YuccBxUcC1")
+    assert daylist["name"] == "Daylist"
+    assert daylist["type"] == "spotify_generated"
+
+    generated = SpotifyPlaylistDetector.get_playlist_info("37i9dQZF1Eunknown000000")
+    assert generated["type"] == "spotify_generated"
+    assert generated["requires_listening_history"] is True
+
+    public = SpotifyPlaylistDetector.get_playlist_info("spotify:playlist:abc123")
+    assert public["type"] == "public"
+    assert public["requires_listening_history"] is False
+
+
+def test_requires_user_auth():
+    assert SpotifyPlaylistDetector.requires_user_auth("37i9dQZF1EP6YuccBxUcC1") is True
+    assert SpotifyPlaylistDetector.requires_user_auth("abc") is False

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -1,0 +1,26 @@
+"""Tests for scheduler timezone helpers."""
+
+from datetime import UTC
+from unittest.mock import patch
+
+from utils.timezone import get_scheduler_timezone, get_utc_now
+
+
+def test_get_scheduler_timezone_prefers_tz_env(monkeypatch):
+    monkeypatch.setenv("TZ", "America/New_York")
+    assert get_scheduler_timezone().key == "America/New_York"
+
+    monkeypatch.delenv("TZ", raising=False)
+    with patch("services.config_service.config_service.get", return_value="UTC"):
+        assert get_scheduler_timezone().key == "UTC"
+
+
+def test_get_scheduler_timezone_invalid_zone_falls_back_to_utc(monkeypatch):
+    monkeypatch.delenv("TZ", raising=False)
+    with patch("services.config_service.config_service.get", return_value="Not/A/Real/Zone"):
+        assert get_scheduler_timezone() is UTC
+
+
+def test_get_utc_now_is_timezone_aware():
+    now = get_utc_now()
+    assert now.tzinfo is not None


### PR DESCRIPTION
Add unit tests for timezone, playlist detection, event dedupe coalescing, Plex account helpers, and Lidarr artist sync; omit example-only utils from coverage; finalize 0.3.17 release metadata.