### PR TITLE
Housekeeping: refresh Trivy ignores and dependency floors for 0.3.18-dev

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: "3.14"
 
       - name: Install Ruff
-        run: pip install ruff==0.15.18
+        run: pip install ruff==0.15.20
 
       - name: Lint
         run: ruff check .

--- a/.trivyignore
+++ b/.trivyignore
@@ -4,52 +4,83 @@
 #
 # Tracker hub: https://security-tracker.debian.org/
 # Typical removal check (in a built container):
-#   dpkg-query -W libssh2-1t64 curl libcurl4t64 libncursesw6 libsqlite3-0 perl-base
+#   dpkg-query -W libssh2-1t64 curl libcurl4t64 libncursesw6 libsqlite3-0 perl-base gzip libacl1
 # ---------------------------------------------------------------------------
 #
-# CVE-2025-69720 — ncurses infocmp stack overflow (CLI tool mitigations)
-#   Debian trixie: open (no-dsa); fixed in Debian sid ncurses 6.6+20251231-1 onward.
+# CVE-2025-69720 — libncursesw6: infocmp stack overflow (CLI tool)
+#   Debian trixie: ncurses 6.5+20250216-2 vulnerable; no-dsa (minor). Fixed in sid 6.6+20251231-1 onward.
 #   Headless CMDARR workload does not run infocmp; exposure is incidental library install.
+#   Tracker: https://security-tracker.debian.org/tracker/CVE-2025-69720
 CVE-2025-69720 exp:2026-09-01
 #
-# CVE-2026-7598 — libssh2: integer overflow in userauth_password (username/password lengths)
-#   Debian trixie: open (libssh2 1.11.1-1); sid 1.11.1-3 fixed per tracker. CMDARR does not expose SSH client to untrusted callers.
-CVE-2026-7598 exp:2026-09-01
+# CVE-2026-41992 — gzip: global buffer over-read in LZH decompressor via stale shared state
+#   Debian trixie: gzip 1.13-1 vulnerable; no-dsa (minor). Upstream fix in commit 63dbf6b; gzip 1.15 not released yet.
+#   Requires crafted LZW then LZH files in the same gzip -d invocation; CMDARR does not decompress untrusted legacy archives.
+#   Tracker: https://security-tracker.debian.org/tracker/CVE-2026-41992
+CVE-2026-41992 exp:2026-09-01
 #
-# CVE-2026-55200 — libssh2: out-of-bounds write via unchecked packet_length in transport.c
-#   Debian trixie: open (libssh2 1.11.1-1); upstream fix in commit 7acf3df, no trixie DSA yet.
-#   libssh2 is a transitive curl dependency; HEALTHCHECK uses curl for local HTTP only—not SSH/SFTP.
-#   Tracker: https://security-tracker.debian.org/tracker/CVE-2026-55200
-CVE-2026-55200 exp:2026-09-01
+# CVE-2026-54369 — libacl1: symlink traversal in pathname-based ACL functions (acl < 2.4.0)
+#   Debian trixie: libacl1 2.3.2-2 vulnerable; fixed in sid acl 2.4.0-1, no trixie DSA yet.
+#   Incidental base-image package; CMDARR does not call getfacl/setfacl/chacl or libacl pathname APIs.
+#   Tracker: https://security-tracker.debian.org/tracker/CVE-2026-54369
+CVE-2026-54369 exp:2026-09-01
 #
-# CVE-2026-55199 — libssh2: pre-auth DoS via SSH_MSG_EXT_INFO extension count loop
-#   Debian trixie: open (libssh2 1.11.1-1); upstream fix in commit 1762685, no trixie DSA yet.
-#   Requires a malicious SSH server; CMDARR does not initiate SSH sessions (curl HTTP healthcheck only).
-#   Tracker: https://security-tracker.debian.org/tracker/CVE-2026-55199
-CVE-2026-55199 exp:2026-09-01
-#
-# CVE-2026-5773 — libcurl: wrongful SMBConnection reuse loads wrong SMB share/path
-#   Debian trixie: vulnerable curl 8.14.1-2+deb13u3 / libcurl4t64; fixed in Debian sid curl 8.20.0-2 onward (no trixie DSA yet).
+# CVE-2026-5773 — libcurl4t64: wrongful SMB connection reuse loads wrong share/path
+#   Debian trixie: curl 8.14.1-2+deb13u3 / libcurl4t64 vulnerable; fixed in sid curl 8.20.0-2 onward (no trixie DSA yet).
 #   Affects libcurl SMB(S) transfers only; CMDARR uses curl only for plain HTTP(S) HEALTHCHECK—not SMB.
 #   Tracker: https://security-tracker.debian.org/tracker/CVE-2026-5773
 CVE-2026-5773 exp:2026-09-01
 #
-# CVE-2026-6276 - libcurl: Information disclosure due to cookie leak when reusing connections
-#   Debian trixie: vulnerable curl 8.14.1-2+deb13u3 / libcurl4t64
+# CVE-2026-6276 — libcurl4t64: cookie leak when reusing easy handle after custom Host header
+#   Debian trixie: curl 8.14.1-2+deb13u3 / libcurl4t64 vulnerable; fixed in sid curl 8.20.0~rc3-1 onward (no trixie DSA yet).
+#   Requires custom Host header on first request then reuse without it; HEALTHCHECK uses a fresh local HTTP probe only.
+#   Tracker: https://security-tracker.debian.org/tracker/CVE-2026-6276
 CVE-2026-6276 exp:2026-09-01
 #
-# CVE-2026-11822 / CVE-2026-11824 — libsqlite3-0: SQLite memory corruption / heap overflow (< 3.53.2)
-#   Debian trixie: libsqlite3-0 3.46.1-7+deb13u1; no trixie security upload yet. CMDARR uses SQLite
-#   only for its local application database, not for parsing untrusted SQLite files from external sources.
+# CVE-2026-11822 — libsqlite3-0: FTS5 memory corruption via crafted database page data (< 3.53.2)
+#   Debian trixie: libsqlite3-0 3.46.1-7+deb13u1 vulnerable; no-dsa (minor). Fixed in sid sqlite3 3.53.2-1 onward.
+#   CMDARR uses SQLite only for its local application database, not for parsing untrusted SQLite files from external sources.
+#   Tracker: https://security-tracker.debian.org/tracker/CVE-2026-11822
 CVE-2026-11822 exp:2026-09-01
+#
+# CVE-2026-11824 — libsqlite3-0: FTS5 heap buffer overflow via crafted continuation page metadata (< 3.53.2)
+#   Debian trixie: libsqlite3-0 3.46.1-7+deb13u1 vulnerable; no-dsa (minor). Fixed in sid sqlite3 3.53.2-1 onward.
+#   CMDARR uses SQLite only for its local application database, not for parsing untrusted SQLite files from external sources.
+#   Tracker: https://security-tracker.debian.org/tracker/CVE-2026-11824
 CVE-2026-11824 exp:2026-09-01
 #
-# perl-base — incidental Debian base-image package (python:3.14-slim-trixie); CMDARR runtime is Python-only.
-#   Archive::Tar / IO::Compress issues require attacker-controlled tar/zip extraction; not in app workload.
-#   Debian trixie: perl-base 5.40.1-6; fixes deferred / not yet in trixie-security.
+# CVE-2026-42496 — perl-base / Archive::Tar: symlink extraction to attacker-controlled path (< 3.08)
+#   Debian trixie: perl-base 5.40.1-6 vulnerable; fix deferred pending upstream Archive::Tar 3.08 (no trixie DSA yet).
+#   Incidental base-image package; CMDARR runtime is Python-only and does not extract attacker-controlled tar archives.
+#   Tracker: https://security-tracker.debian.org/tracker/CVE-2026-42496
 CVE-2026-42496 exp:2026-09-01
+#
+# CVE-2026-8376 — perl-base: heap buffer overflow compiling regex with repeated fixed string (32-bit builds)
+#   Debian trixie: perl-base 5.40.1-6 vulnerable; no-dsa (minor). Fixed in sid perl 5.40.1-8 onward.
+#   Requires attacker-controlled regex compilation on 32-bit Perl; CMDARR runs Python on amd64/arm64 only.
+#   Tracker: https://security-tracker.debian.org/tracker/CVE-2026-8376
 CVE-2026-8376 exp:2026-09-01
+#
+# CVE-2026-42497 — perl-base / Archive::Tar: hardlink extraction to attacker-controlled path (< 3.08)
+#   Debian trixie: perl-base 5.40.1-6 vulnerable; fix deferred pending upstream Archive::Tar 3.08 (no trixie DSA yet).
+#   Incidental base-image package; CMDARR runtime is Python-only and does not extract attacker-controlled tar archives.
+#   Tracker: https://security-tracker.debian.org/tracker/CVE-2026-42497
 CVE-2026-42497 exp:2026-09-01
+#
+# CVE-2026-48959 — perl-base / IO::Uncompress::Unzip: CPU exhaustion via per-byte read loop (< 2.220)
+#   Debian trixie: perl-base 5.40.1-6 / libio-compress-perl 2.213-1 vulnerable; fixed in sid libio-compress-perl 2.220-1 onward.
+#   Requires extracting a named entry from attacker-supplied zip; CMDARR does not process untrusted zip archives via Perl.
+#   Tracker: https://security-tracker.debian.org/tracker/CVE-2026-48959
 CVE-2026-48959 exp:2026-09-01
+#
+# CVE-2026-48962 — perl-base / IO::Compress: arbitrary code via attacker-controlled output glob (< 2.220)
+#   Debian trixie: perl-base 5.40.1-6 / libio-compress-perl 2.213-1 vulnerable; fixed in sid libio-compress-perl 2.220-1 onward.
+#   Requires attacker-controlled output glob passed to IO::Compress; CMDARR does not invoke Perl compression utilities.
+#   Tracker: https://security-tracker.debian.org/tracker/CVE-2026-48962
 CVE-2026-48962 exp:2026-09-01
+#
+# CVE-2026-9538 — perl-base / Archive::Tar: memory exhaustion via unbounded tar entry size field (< 3.10)
+#   Debian trixie: perl-base 5.40.1-6 vulnerable; fix deferred pending upstream Archive::Tar 3.10 (no trixie DSA yet).
+#   Requires parsing attacker-controlled tar headers; CMDARR does not extract untrusted tar archives via Perl.
+#   Tracker: https://security-tracker.debian.org/tracker/CVE-2026-9538
 CVE-2026-9538 exp:2026-09-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.18-dev] - TBD
+
+### Features
+- N/A
+
+### Fixes
+- N/A
+
+### Housekeeping
+- **Security**: Review of .trivyignore; removed CVEs that now have a fix, and added 2 new ignores related to gzip and libacl1
+- **Python Package Update**: Review and update of Python packages.
+- **Node Package Update**: Review and update of Node packages.
+
 ## [0.3.17] - 2026-06-25
 
 ### Features

--- a/__version__.py
+++ b/__version__.py
@@ -4,4 +4,4 @@ Cmdarr version information
 Bump only at release; during development use a -dev suffix (e.g. 0.3.14-dev).
 """
 
-__version__ = "0.3.17"
+__version__ = "0.3.18-dev"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -61,5 +61,8 @@
     "@typescript-eslint/typescript-estree": {
       "minimatch": "9.0.7"
     }
+  },
+  "allowScripts": {
+    "fsevents@2.3.3": true
   }
 }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,8 @@
 # requirements-dev.txt
 -r requirements.txt
-ruff==0.15.18
-pytest>=9.1.0
+ruff==0.15.20
+pytest>=9.1.1
 pytest-asyncio>=1.4.0
 pytest-cov>=7.1.0
-coverage>=7.14.3
+coverage>=7.15.0
 httpx>=0.28.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ aiohttp>=3.14.1
 curl-cffi>=0.15.0
 
 # Synchronous HTTP client for Plex API (proven working approach)
-requests>=2.34.0
+requests>=2.34.2
 # Explicit floor: transitive CVEs CVE-2026-44431, CVE-2026-44432 (Trivy) fixed in urllib3>=2.7.0
 urllib3>=2.7.0
 
@@ -13,11 +13,11 @@ urllib3>=2.7.0
 aiofiles>=25.1.0
 
 # System process and memory monitoring for library cache management
-psutil>=7.0.0
+psutil>=7.2.2
 
 # FastAPI and web framework dependencies
-fastapi>=0.138.0
-uvicorn[standard]>=0.49.0
+fastapi>=0.139.0
+uvicorn[standard]>=0.50.2
 jinja2>=3.1.6
 python-multipart>=0.0.32
 
@@ -28,32 +28,32 @@ sqlalchemy>=2.0.51
 pydantic>=2.13.4
 
 # Cron schedule parsing for scheduler
-croniter>=6.2.0
+croniter>=6.2.3
 
 # Image processing for daylist cover generation (Meloday-style)
-Pillow>=12.2.0
+Pillow>=12.3.0
 
 # IANA timezone database (required for zoneinfo on minimal Linux/Docker; optional on macOS/Windows)
 tzdata>=2026.2
 
 # Spotify playlist scraping (no credentials required for public playlists)
-spotifyscraper>=3.9.1,<4.0.0
+spotifyscraper>=3.9.2,<4.0.0
 rich>=15.0.0
 # Direct pin: transitive spotifyscraper → rich → pygments (CVE-2026-4539 / GHSA-5239-wwwm-4pmq)
 Pygments>=2.20.0
 
 # Password hashing for access control (bcrypt directly; passlib unmaintained, incompatible with bcrypt 4.1+)
-bcrypt>=4.3.0
+bcrypt>=5.0.0
 
 # Transitive floors — parent packages only require minimum versions; explicit pins keep
 # resolver on current stable releases (pydantic-core stays on pydantic's pin until upstream bumps).
 starlette>=1.3.1
-aiohappyeyeballs>=2.6.2
-anyio>=4.14.0
+aiohappyeyeballs>=2.7.1
+anyio>=4.14.1
 attrs>=26.1.0
 certifi>=2026.6.17
-charset-normalizer>=3.4.7
-click>=8.4.1
+charset-normalizer>=3.4.8
+click>=8.4.2
 idna>=3.18
 markdown-it-py>=4.2.0
 packaging>=26.2
@@ -67,14 +67,10 @@ soupsieve>=2.8.4
 tqdm>=4.68.3
 tomli>=2.4.1
 msgpack>=1.2.1
-filelock>=3.29.4
+filelock>=3.29.5
 
 # For enhanced logging and formatting
 # colorlog>=6.7.0
 
 # For future scheduling functionality
 # apscheduler>=3.10.0
-
-# Development and testing (optional)
-# pytest>=7.4.0
-# pytest-asyncio>=0.21.0


### PR DESCRIPTION
…dev.

Unblock weekly image rebuilds by auditing .trivyignore, bump Python and Node tooling floors, and start the 0.3.18-dev release cycle.