### PR TITLE
Fix Artist Essentials silently skipping artists with sparse Last.fm d…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 - **Playlist matching**: Artist Essentials and related playlist commands disambiguate short punctuation-sensitive names (e.g. `Gore.` vs `gore`) using Lidarr MBIDs and strict artist identity checks so Last.fm and Plex lookups target the correct band.
-- **Artist Essentials**: Last.fm top-track fetch now falls back from MBID to artist name, then Plex library popular tracks, with visible logging when an artist is skipped; duplicate artist entries in a command list are deduplicated.
+- **Artist Essentials**: Last.fm top-track fetch prefers punctuation-preserving artist names before Lidarr MBIDs (Last.fm often lacks MB links — e.g. `Gore.` is found by name but not by MusicBrainz ID), falls back to Plex library popular tracks when needed, logs skipped artists, and deduplicates duplicate entries in a command list.
 
 ### Housekeeping
 - **Docker**: Drop Debian-based runtime image; Wolfi/Chainguard (`Dockerfile`, digest-pinned Python 3.14) is now the sole published image. Develop publishes `:develop`; releases publish `latest`, `v0`, `v0.3`, and patch tags only (no `-wolfi` suffix or Debian fallback).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 - **Playlist matching**: Artist Essentials and related playlist commands disambiguate short punctuation-sensitive names (e.g. `Gore.` vs `gore`) using Lidarr MBIDs and strict artist identity checks so Last.fm and Plex lookups target the correct band.
-- **Artist Essentials**: Last.fm top-track fetch prefers punctuation-preserving artist names before Lidarr MBIDs (Last.fm often lacks MB links — e.g. `Gore.` is found by name but not by MusicBrainz ID), falls back to Plex library popular tracks when needed, logs skipped artists, and deduplicates duplicate entries in a command list.
+- **Artist Essentials**: Last.fm lookup order is MBID → exact artist name (punctuation preserved) → normalized fallback; Lidarr artists validate fetched tracks against Plex before use, Plex sync escalates artist matching the same way, and logs a warning when 0/N tracks match for a library artist.
 
 ### Housekeeping
 - **Docker**: Drop Debian-based runtime image; Wolfi/Chainguard (`Dockerfile`, digest-pinned Python 3.14) is now the sole published image. Develop publishes `:develop`; releases publish `latest`, `v0`, `v0.3`, and patch tags only (no `-wolfi` suffix or Debian fallback).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 - **Playlist matching**: Artist Essentials and related playlist commands disambiguate short punctuation-sensitive names (e.g. `Gore.` vs `gore`) using Lidarr MBIDs and strict artist identity checks so Last.fm and Plex lookups target the correct band.
+- **Artist Essentials**: Last.fm top-track fetch now falls back from MBID to artist name, then Plex library popular tracks, with visible logging when an artist is skipped; duplicate artist entries in a command list are deduplicated.
 
 ### Housekeeping
 - **Docker**: Drop Debian-based runtime image; Wolfi/Chainguard (`Dockerfile`, digest-pinned Python 3.14) is now the sole published image. Develop publishes `:develop`; releases publish `latest`, `v0`, `v0.3`, and patch tags only (no `-wolfi` suffix or Debian fallback).

--- a/clients/client_lastfm.py
+++ b/clients/client_lastfm.py
@@ -215,6 +215,13 @@ class LastFMClient(BaseAPIClient):
     ) -> list[dict[str, Any]]:
         if not response:
             return []
+        if response.get("error"):
+            self.logger.debug(
+                "Last.fm top tracks error %s: %s",
+                response.get("error"),
+                response.get("message", ""),
+            )
+            return []
         toptracks = response.get("toptracks", {})
         track_list = toptracks.get("track", [])
         if isinstance(track_list, dict):

--- a/clients/client_lastfm.py
+++ b/clients/client_lastfm.py
@@ -210,6 +210,31 @@ class LastFMClient(BaseAPIClient):
 
             return [], []
 
+    def _parse_top_tracks_response(
+        self, response: dict[str, Any] | None, default_artist: str
+    ) -> list[dict[str, Any]]:
+        if not response:
+            return []
+        toptracks = response.get("toptracks", {})
+        track_list = toptracks.get("track", [])
+        if isinstance(track_list, dict):
+            track_list = [track_list]
+
+        tracks: list[dict[str, Any]] = []
+        for t in track_list:
+            name = t.get("name", "").strip()
+            art = t.get("artist", {})
+            artist = art.get("name", default_artist) if isinstance(art, dict) else default_artist
+            if name:
+                tracks.append(
+                    {
+                        "name": name,
+                        "artist": artist,
+                        "playcount": int(t.get("playcount", 0)),
+                    }
+                )
+        return tracks
+
     async def get_top_tracks(
         self,
         artist_name: str,
@@ -220,82 +245,97 @@ class LastFMClient(BaseAPIClient):
         """
         Get top tracks for an artist via artist.getTopTracks.
         Returns list of {name, artist, playcount} for matching against library.
+        Tries MBID first when provided, then falls back to artist name (like get_similar_artists).
         """
         mbid = (mbid or "").strip() or None
         name_clean = (artist_name or "").strip()
         if not mbid and not name_clean:
             return []
 
-        cache_key = f"toptracks:{mbid or name_clean}:{limit}"
-        if self.cache_enabled and self.cache:
-            if self.cache.is_failed_lookup(cache_key, "lastfm"):
-                return []
-            cached = self.cache.get(cache_key, "lastfm")
-            if cached is not None:
-                self.logger.debug(f"Cache hit for top tracks: {mbid or name_clean}")
-                return cached.get("tracks", [])
+        limit_str = str(min(limit, 50))
+        default_artist = name_clean or artist_name or ""
 
-        params: dict[str, str] = {
-            "method": "artist.getTopTracks",
-            "limit": str(min(limit, 50)),
-        }
-        if mbid:
-            params["mbid"] = mbid
-        else:
-            params["artist"] = name_clean
-        context = f"top tracks for '{name_clean}'" + (f" (MBID: {mbid})" if mbid else "")
-        try:
+        async def _request_top_tracks(params: dict[str, str], context: str) -> list[dict[str, Any]]:
             response = await self._make_request(params, context_info=context)
-            if not response:
+            return self._parse_top_tracks_response(response, default_artist)
+
+        tracks: list[dict[str, Any]] = []
+        mbid_cache_key = f"toptracks:mbid:{mbid}:{limit}" if mbid else None
+        name_cache_key = f"toptracks:name:{name_clean.lower()}:{limit}" if name_clean else None
+
+        try:
+            if mbid:
                 if self.cache_enabled and self.cache:
-                    self.cache.mark_failed_lookup(
-                        cache_key,
+                    if self.cache.is_failed_lookup(mbid_cache_key, "lastfm"):
+                        pass
+                    else:
+                        cached = self.cache.get(mbid_cache_key, "lastfm")
+                        if cached is not None:
+                            self.logger.debug(f"Cache hit for top tracks MBID: {mbid}")
+                            tracks = cached.get("tracks", [])
+                            if tracks:
+                                return tracks
+
+                if not tracks:
+                    params = {
+                        "method": "artist.getTopTracks",
+                        "mbid": mbid,
+                        "limit": limit_str,
+                    }
+                    context = f"top tracks for '{name_clean}' (MBID: {mbid})"
+                    tracks = await _request_top_tracks(params, context)
+                    if tracks and self.cache_enabled and self.cache:
+                        self.cache.set(
+                            mbid_cache_key,
+                            "lastfm",
+                            {"tracks": tracks},
+                            self.config.CACHE_LASTFM_TTL_DAYS,
+                        )
+                    if tracks:
+                        return tracks
+
+            if name_clean:
+                if self.cache_enabled and self.cache:
+                    if self.cache.is_failed_lookup(name_cache_key, "lastfm"):
+                        return []
+                    cached = self.cache.get(name_cache_key, "lastfm")
+                    if cached is not None:
+                        self.logger.debug(f"Cache hit for top tracks name: {name_clean}")
+                        return cached.get("tracks", [])
+
+                if mbid:
+                    self.logger.debug(
+                        f"MBID top tracks empty for '{name_clean}' (MBID: {mbid}), "
+                        "trying name-based query"
+                    )
+                params = {
+                    "method": "artist.getTopTracks",
+                    "artist": name_clean,
+                    "limit": limit_str,
+                }
+                context = f"top tracks for '{name_clean}' (name)"
+                tracks = await _request_top_tracks(params, context)
+                if self.cache_enabled and self.cache and tracks:
+                    self.cache.set(
+                        name_cache_key,
                         "lastfm",
-                        "API request failed",
-                        self.config.CACHE_FAILED_LOOKUP_TTL_DAYS,
+                        {"tracks": tracks},
+                        self.config.CACHE_LASTFM_TTL_DAYS,
                     )
-                return []
+                return tracks
 
-            toptracks = response.get("toptracks", {})
-            track_list = toptracks.get("track", [])
-            if isinstance(track_list, dict):
-                track_list = [track_list]
-
-            tracks = []
-            for t in track_list:
-                name = t.get("name", "").strip()
-                art = t.get("artist", {})
-                artist = (
-                    art.get("name", name_clean or artist_name)
-                    if isinstance(art, dict)
-                    else (name_clean or artist_name)
-                )
-                if name:
-                    tracks.append(
-                        {
-                            "name": name,
-                            "artist": artist,
-                            "playcount": int(t.get("playcount", 0)),
-                        }
-                    )
-
-            if self.cache_enabled and self.cache:
-                self.cache.set(
-                    cache_key,
-                    "lastfm",
-                    {"tracks": tracks},
-                    self.config.CACHE_LASTFM_TTL_DAYS,
-                )
-            return tracks
+            return []
         except Exception as e:
             self.logger.error(f"Error getting top tracks for {mbid or name_clean}: {e}")
             if self.cache_enabled and self.cache:
-                self.cache.mark_failed_lookup(
-                    cache_key,
-                    "lastfm",
-                    str(e),
-                    self.config.CACHE_FAILED_LOOKUP_TTL_DAYS,
-                )
+                fail_key = name_cache_key or mbid_cache_key
+                if fail_key:
+                    self.cache.mark_failed_lookup(
+                        fail_key,
+                        "lastfm",
+                        str(e),
+                        self.config.CACHE_FAILED_LOOKUP_TTL_DAYS,
+                    )
             return []
 
     async def get_artist_info(

--- a/clients/client_plex.py
+++ b/clients/client_plex.py
@@ -727,6 +727,36 @@ class PlexClient(BaseAPIClient):
 
         return self._search_for_track_live(track_name, artist_name, mbids, album_name)
 
+    def search_for_track_escalating(
+        self,
+        track_name: str,
+        match_context: dict[str, Any],
+        cached_data: dict[str, Any] | None = None,
+        album_name: str = "",
+    ) -> str | None:
+        """Try MBID + exact artist names, then normalized name, for Plex track lookup."""
+        from utils.track_match import plex_search_variants
+
+        display = match_context.get("display_name") or ""
+        for artist_name, mbids, strategy in plex_search_variants(match_context):
+            key = self.search_for_track(
+                track_name,
+                artist_name,
+                mbids=mbids,
+                cached_data=cached_data,
+                album_name=album_name,
+            )
+            if key:
+                if strategy == "normalized":
+                    self.logger.warning(
+                        "Plex matched '%s' via normalized artist '%s' (expected '%s')",
+                        track_name,
+                        artist_name,
+                        display,
+                    )
+                return key
+        return None
+
     def _search_for_track_live(self, track_name, artist_name, mbids=None, album_name=None):
         """
         Live API search using mediaQuery on /all (fallback when cache unavailable).
@@ -842,6 +872,25 @@ class PlexClient(BaseAPIClient):
             found_track_keys = []
             failed_matches = []
             processed = 0
+            artist_match_stats: dict[str, dict[str, Any]] = {}
+
+            def _artist_stat_key(track_row: dict[str, Any]) -> str:
+                ctx = track_row.get("match_context") or {}
+                return str(ctx.get("norm") or track_row.get("artist") or "").strip() or "unknown"
+
+            def _record_artist_match(track_row: dict[str, Any], matched: bool) -> None:
+                ctx = track_row.get("match_context") or {}
+                key = _artist_stat_key(track_row)
+                if key not in artist_match_stats:
+                    artist_match_stats[key] = {
+                        "display_name": ctx.get("display_name") or track_row.get("artist", key),
+                        "expected": 0,
+                        "matched": 0,
+                        "in_lidarr": bool(ctx.get("in_lidarr")),
+                    }
+                artist_match_stats[key]["expected"] += 1
+                if matched:
+                    artist_match_stats[key]["matched"] += 1
 
             for _i, track in enumerate(tracks):
                 # Support pre-resolved rating keys (e.g. from Plex popular tracks)
@@ -851,6 +900,7 @@ class PlexClient(BaseAPIClient):
                     processed += 1
                     artist = track.get("artist", "")
                     track_name = track.get("track", "")
+                    _record_artist_match(track, True)
                     progress = f"[{processed}/{len(tracks)}]"
                     if artist and track_name:
                         self.logger.info(f"{progress} ✅ {artist} - {track_name}")
@@ -879,20 +929,44 @@ class PlexClient(BaseAPIClient):
                 self.logger.debug(
                     f"Searching for track: '{artist}' - '{track_name}' - Album: '{album}' - Cache: {cached_data is not None}"
                 )
-                rating_key = self.search_for_track(
-                    track_name,
-                    artist,
-                    mbids=mbids,
-                    cached_data=cached_data,
-                    album_name=album,
-                )
+                match_context = track.get("match_context")
+                if match_context:
+                    rating_key = self.search_for_track_escalating(
+                        track_name,
+                        match_context,
+                        cached_data=cached_data,
+                        album_name=album,
+                    )
+                else:
+                    rating_key = self.search_for_track(
+                        track_name,
+                        artist,
+                        mbids=mbids,
+                        cached_data=cached_data,
+                        album_name=album,
+                    )
 
                 if rating_key:
                     found_track_keys.append(rating_key)
+                    _record_artist_match(track, True)
                     self.logger.info(f"{progress} ✅ {artist} - {track_name}")
                 else:
                     failed_matches.append(f"{artist} - {track_name}")
+                    _record_artist_match(track, False)
                     self.logger.info(f"{progress} ❌ {artist} - {track_name}")
+
+            for stat in artist_match_stats.values():
+                if (
+                    stat.get("in_lidarr")
+                    and stat.get("expected", 0) > 0
+                    and stat.get("matched", 0) == 0
+                ):
+                    self.logger.warning(
+                        "Likely Plex matching failure for '%s': 0/%s tracks matched "
+                        "(artist is in Lidarr/library)",
+                        stat.get("display_name"),
+                        stat.get("expected"),
+                    )
 
             tracks_found = len(found_track_keys)
             tracks_total = len(tracks)
@@ -962,6 +1036,7 @@ class PlexClient(BaseAPIClient):
                     "total_tracks": tracks_total,
                     "found_tracks": tracks_found,
                     "unmatched_tracks": failed_matches,
+                    "artist_match_stats": artist_match_stats,
                     "message": f"Successfully synced playlist '{title}' with {tracks_found} tracks",
                 }
             else:

--- a/clients/client_plex.py
+++ b/clients/client_plex.py
@@ -390,8 +390,7 @@ class PlexClient(BaseAPIClient):
                         str(tracks_by_key.get(key, {}).get("artist", "") or ""),
                     )
                 }
-                if identity_candidates:
-                    artist_candidates = identity_candidates
+                artist_candidates = identity_candidates
             candidate_keys.update(artist_candidates)
             self.logger.debug(
                 f"🔍 CACHED SEARCH: Artist '{artist_lower}' found {len(artist_candidates)} candidates: {sorted(artist_candidates)[:10]}"

--- a/commands/playlist_generator_helpers.py
+++ b/commands/playlist_generator_helpers.py
@@ -285,6 +285,19 @@ def _plex_popular_rows_for_resolved(
     return rows
 
 
+def _lastfm_name_candidates(resolved: ResolvedArtist) -> list[str]:
+    """Distinct Last.fm artist query names; preserve punctuation (``Gore.`` not ``gore``)."""
+    seen_lower: set[str] = set()
+    names: list[str] = []
+    for raw in (resolved.display_name, resolved.library_artist):
+        name = (raw or "").strip()
+        key = name.lower()
+        if name and key not in seen_lower:
+            seen_lower.add(key)
+            names.append(name)
+    return names
+
+
 async def fetch_top_tracks_for_artist(
     resolved: ResolvedArtist,
     *,
@@ -295,27 +308,24 @@ async def fetch_top_tracks_for_artist(
     limit: int,
     logger: Any,
 ) -> tuple[list[dict[str, Any]], str]:
-    """Resolve top tracks for one artist: Last.fm (MBID/name/library name) then Plex library."""
+    """Resolve top tracks for one artist: Last.fm names, then MBID, then Plex library."""
     mbid = resolved.mbids[0] if len(resolved.mbids) == 1 else None
 
-    lastfm_tracks = await lastfm_client.get_top_tracks(
-        resolved.display_name,
-        limit=limit,
-        mbid=mbid,
-    )
-    if lastfm_tracks:
-        return _lastfm_rows_for_resolved(resolved, lastfm_tracks, limit), "lastfm"
-
-    library_name = (resolved.library_artist or "").strip()
-    if library_name and library_name.lower() != resolved.display_name.lower():
-        lastfm_tracks = await lastfm_client.get_top_tracks(library_name, limit=limit)
+    # Last.fm often lacks Lidarr/MusicBrainz MBID links (e.g. Gore. has mbid=None on Last.fm).
+    # Name lookup with punctuation is required — "gore" resolves to a different artist.
+    for name in _lastfm_name_candidates(resolved):
+        lastfm_tracks = await lastfm_client.get_top_tracks(name, limit=limit)
         if lastfm_tracks:
-            logger.info(
-                "Using Last.fm library artist name '%s' for '%s'",
-                library_name,
-                resolved.display_name,
-            )
-            return _lastfm_rows_for_resolved(resolved, lastfm_tracks, limit), "lastfm_library_name"
+            return _lastfm_rows_for_resolved(resolved, lastfm_tracks, limit), "lastfm"
+
+    if mbid:
+        lastfm_tracks = await lastfm_client.get_top_tracks(
+            resolved.display_name,
+            limit=limit,
+            mbid=mbid,
+        )
+        if lastfm_tracks:
+            return _lastfm_rows_for_resolved(resolved, lastfm_tracks, limit), "lastfm_mbid"
 
     if plex_client and library_key:
         plex_rows = _plex_popular_rows_for_resolved(
@@ -329,8 +339,9 @@ async def fetch_top_tracks_for_artist(
             return plex_rows, "plex"
 
     logger.warning(
-        "No top tracks for '%s' (tried Last.fm mbid=%s, name, library name; Plex fallback empty)",
+        "No top tracks for '%s' (tried Last.fm names=%s, mbid=%s; Plex fallback empty)",
         resolved.display_name,
+        _lastfm_name_candidates(resolved),
         mbid or "none",
     )
     return [], "none"

--- a/commands/playlist_generator_helpers.py
+++ b/commands/playlist_generator_helpers.py
@@ -8,7 +8,11 @@ from difflib import SequenceMatcher
 from typing import Any
 
 from utils.text_normalizer import normalize_text
-from utils.track_match import artist_identity_matches
+from utils.track_match import (
+    artist_identity_matches,
+    lastfm_query_plan,
+    lastfm_tracks_match_artist,
+)
 
 SEP = " · "
 MAX_ARTIST_LEN = 40
@@ -235,6 +239,22 @@ def resolve_validated_artists(
     return resolved, invalid
 
 
+def artist_match_context(resolved: ResolvedArtist) -> dict[str, Any]:
+    return {
+        "display_name": resolved.display_name,
+        "library_artist": resolved.library_artist,
+        "norm": resolved.norm,
+        "mbids": list(resolved.mbids),
+        "in_lidarr": bool(resolved.mbids),
+    }
+
+
+def attach_match_context(row: dict[str, Any], resolved: ResolvedArtist) -> dict[str, Any]:
+    enriched = dict(row)
+    enriched["match_context"] = artist_match_context(resolved)
+    return enriched
+
+
 def _lastfm_rows_for_resolved(
     resolved: ResolvedArtist, lastfm_tracks: list[dict[str, Any]], limit: int
 ) -> list[dict[str, Any]]:
@@ -251,7 +271,7 @@ def _lastfm_rows_for_resolved(
         }
         if mbid:
             row["mbid"] = mbid
-        rows.append(row)
+        rows.append(attach_match_context(row, resolved))
     return rows
 
 
@@ -274,28 +294,43 @@ def _plex_popular_rows_for_resolved(
     rows: list[dict[str, Any]] = []
     for t in popular[:limit]:
         rows.append(
-            {
-                "rating_key": t["key"],
-                "artist": t.get("artist") or resolved.library_artist,
-                "track": t["title"],
-                "album": t.get("album", ""),
-                **({"mbid": mbid} if mbid else {}),
-            }
+            attach_match_context(
+                {
+                    "rating_key": t["key"],
+                    "artist": t.get("artist") or resolved.library_artist,
+                    "track": t["title"],
+                    "album": t.get("album", ""),
+                    **({"mbid": mbid} if mbid else {}),
+                },
+                resolved,
+            )
         )
     return rows
 
 
-def _lastfm_name_candidates(resolved: ResolvedArtist) -> list[str]:
-    """Distinct Last.fm artist query names; preserve punctuation (``Gore.`` not ``gore``)."""
-    seen_lower: set[str] = set()
-    names: list[str] = []
-    for raw in (resolved.display_name, resolved.library_artist):
-        name = (raw or "").strip()
-        key = name.lower()
-        if name and key not in seen_lower:
-            seen_lower.add(key)
-            names.append(name)
-    return names
+def _probe_tracks_match_library(
+    track_rows: list[dict[str, Any]],
+    resolved: ResolvedArtist,
+    plex_client: Any,
+    cached_data: dict[str, Any] | None,
+) -> int:
+    """Return how many track titles resolve in Plex using escalating artist search."""
+    if not plex_client or not cached_data or not track_rows:
+        return 0
+    ctx = artist_match_context(resolved)
+    matched = 0
+    for row in track_rows:
+        track_name = (row.get("track") or "").strip()
+        if not track_name:
+            continue
+        if plex_client.search_for_track_escalating(
+            track_name,
+            ctx,
+            cached_data=cached_data,
+            album_name=row.get("album", ""),
+        ):
+            matched += 1
+    return matched
 
 
 async def fetch_top_tracks_for_artist(
@@ -308,24 +343,48 @@ async def fetch_top_tracks_for_artist(
     limit: int,
     logger: Any,
 ) -> tuple[list[dict[str, Any]], str]:
-    """Resolve top tracks for one artist: Last.fm names, then MBID, then Plex library."""
-    mbid = resolved.mbids[0] if len(resolved.mbids) == 1 else None
+    """Resolve top tracks: Last.fm (MBID → exact name → normalized), then Plex library."""
+    plan = lastfm_query_plan(
+        resolved.display_name,
+        resolved.library_artist,
+        resolved.norm,
+        resolved.mbids,
+    )
 
-    # Last.fm often lacks Lidarr/MusicBrainz MBID links (e.g. Gore. has mbid=None on Last.fm).
-    # Name lookup with punctuation is required — "gore" resolves to a different artist.
-    for name in _lastfm_name_candidates(resolved):
-        lastfm_tracks = await lastfm_client.get_top_tracks(name, limit=limit)
-        if lastfm_tracks:
-            return _lastfm_rows_for_resolved(resolved, lastfm_tracks, limit), "lastfm"
+    for name, mbid, label in plan:
+        lastfm_tracks = await lastfm_client.get_top_tracks(name, limit=limit, mbid=mbid)
+        if not lastfm_tracks:
+            continue
+        if label == "normalized" and not lastfm_tracks_match_artist(
+            lastfm_tracks, resolved.display_name, resolved.library_artist
+        ):
+            logger.warning(
+                "Last.fm normalized name '%s' returned unrelated artist for '%s'; skipping",
+                name,
+                resolved.display_name,
+            )
+            continue
 
-    if mbid:
-        lastfm_tracks = await lastfm_client.get_top_tracks(
-            resolved.display_name,
-            limit=limit,
-            mbid=mbid,
-        )
-        if lastfm_tracks:
-            return _lastfm_rows_for_resolved(resolved, lastfm_tracks, limit), "lastfm_mbid"
+        rows = _lastfm_rows_for_resolved(resolved, lastfm_tracks, limit)
+        if resolved.mbids and plex_client and cached_data:
+            matched = _probe_tracks_match_library(rows, resolved, plex_client, cached_data)
+            if matched == 0:
+                logger.warning(
+                    "Last.fm returned %s tracks for '%s' (%s) but none matched Plex; trying next source",
+                    len(rows),
+                    resolved.display_name,
+                    label,
+                )
+                continue
+            if matched < len(rows):
+                logger.info(
+                    "Last.fm '%s': %s/%s tracks verified in Plex library",
+                    resolved.display_name,
+                    matched,
+                    len(rows),
+                )
+
+        return rows, f"lastfm_{label}"
 
     if plex_client and library_key:
         plex_rows = _plex_popular_rows_for_resolved(
@@ -333,16 +392,16 @@ async def fetch_top_tracks_for_artist(
         )
         if plex_rows:
             logger.info(
-                "Using Plex library tracks for '%s' (Last.fm had no data)",
+                "Using Plex library tracks for '%s' (Last.fm lookups exhausted)",
                 resolved.display_name,
             )
             return plex_rows, "plex"
 
+    tried = [f"{label}:{name}" + (f"(mbid={mbid})" if mbid else "") for name, mbid, label in plan]
     logger.warning(
-        "No top tracks for '%s' (tried Last.fm names=%s, mbid=%s; Plex fallback empty)",
+        "No top tracks for '%s' (tried %s; Plex fallback empty)",
         resolved.display_name,
-        _lastfm_name_candidates(resolved),
-        mbid or "none",
+        ", ".join(tried) or "nothing",
     )
     return [], "none"
 

--- a/commands/playlist_generator_helpers.py
+++ b/commands/playlist_generator_helpers.py
@@ -216,10 +216,12 @@ def resolve_validated_artists(
     pairs = lidarr_pairs if lidarr_pairs is not None else load_lidarr_artist_pairs_sync()
 
     resolved: list[ResolvedArtist] = []
+    seen_norms: set[str] = set()
     for name in names:
         norm = normalize_text(name.lower())
-        if norm not in valid_set:
+        if norm not in valid_set or norm in seen_norms:
             continue
+        seen_norms.add(norm)
         mbids = _pick_lidarr_mbids(name, norm, pairs)
         library_artist = _pick_library_artist(name, norm, cached_data)
         resolved.append(
@@ -231,6 +233,107 @@ def resolve_validated_artists(
             )
         )
     return resolved, invalid
+
+
+def _lastfm_rows_for_resolved(
+    resolved: ResolvedArtist, lastfm_tracks: list[dict[str, Any]], limit: int
+) -> list[dict[str, Any]]:
+    mbid = resolved.mbids[0] if len(resolved.mbids) == 1 else None
+    rows: list[dict[str, Any]] = []
+    for t in lastfm_tracks[:limit]:
+        track_name = (t.get("name") or "").strip()
+        if not track_name:
+            continue
+        row: dict[str, Any] = {
+            "artist": resolved.library_artist,
+            "track": track_name,
+            "album": t.get("album", ""),
+        }
+        if mbid:
+            row["mbid"] = mbid
+        rows.append(row)
+    return rows
+
+
+def _plex_popular_rows_for_resolved(
+    resolved: ResolvedArtist,
+    plex_client: Any,
+    library_key: str,
+    cached_data: dict[str, Any] | None,
+    limit: int,
+) -> list[dict[str, Any]]:
+    track_keys = resolve_artist_track_keys(cached_data, resolved)
+    if not track_keys:
+        return []
+    first_track_key = track_keys[0]
+    artist_rk = plex_client.get_artist_rating_key_from_track(first_track_key)
+    if not artist_rk:
+        return []
+    popular = plex_client.get_artist_popular_tracks(library_key, artist_rk, limit=limit)
+    mbid = resolved.mbids[0] if len(resolved.mbids) == 1 else None
+    rows: list[dict[str, Any]] = []
+    for t in popular[:limit]:
+        rows.append(
+            {
+                "rating_key": t["key"],
+                "artist": t.get("artist") or resolved.library_artist,
+                "track": t["title"],
+                "album": t.get("album", ""),
+                **({"mbid": mbid} if mbid else {}),
+            }
+        )
+    return rows
+
+
+async def fetch_top_tracks_for_artist(
+    resolved: ResolvedArtist,
+    *,
+    lastfm_client: Any,
+    plex_client: Any | None,
+    library_key: str | None,
+    cached_data: dict[str, Any] | None,
+    limit: int,
+    logger: Any,
+) -> tuple[list[dict[str, Any]], str]:
+    """Resolve top tracks for one artist: Last.fm (MBID/name/library name) then Plex library."""
+    mbid = resolved.mbids[0] if len(resolved.mbids) == 1 else None
+
+    lastfm_tracks = await lastfm_client.get_top_tracks(
+        resolved.display_name,
+        limit=limit,
+        mbid=mbid,
+    )
+    if lastfm_tracks:
+        return _lastfm_rows_for_resolved(resolved, lastfm_tracks, limit), "lastfm"
+
+    library_name = (resolved.library_artist or "").strip()
+    if library_name and library_name.lower() != resolved.display_name.lower():
+        lastfm_tracks = await lastfm_client.get_top_tracks(library_name, limit=limit)
+        if lastfm_tracks:
+            logger.info(
+                "Using Last.fm library artist name '%s' for '%s'",
+                library_name,
+                resolved.display_name,
+            )
+            return _lastfm_rows_for_resolved(resolved, lastfm_tracks, limit), "lastfm_library_name"
+
+    if plex_client and library_key:
+        plex_rows = _plex_popular_rows_for_resolved(
+            resolved, plex_client, library_key, cached_data, limit
+        )
+        if plex_rows:
+            logger.info(
+                "Using Plex library tracks for '%s' (Last.fm had no data)",
+                resolved.display_name,
+            )
+            return plex_rows, "plex"
+
+    logger.warning(
+        "No top tracks for '%s' (tried Last.fm mbid=%s, name, library name; Plex fallback empty)",
+        resolved.display_name,
+        mbid or "none",
+    )
+    return [], "none"
 
 
 def load_lidarr_artist_norm_mbid_index_sync() -> dict[str, list[str]]:

--- a/commands/playlist_generator_lfm_similar.py
+++ b/commands/playlist_generator_lfm_similar.py
@@ -16,6 +16,7 @@ from .playlist_generator_helpers import (
     build_lfm_similar_artist_pool,
     compute_lfm_similar_playlist_title,
     delete_playlist_on_target,
+    fetch_top_tracks_for_artist,
     persist_playlist_identity,
     resolve_validated_artists,
     validate_artists_against_cache,
@@ -151,6 +152,7 @@ class PlaylistGeneratorLfmSimilarCommand(BaseCommand):
             tracks_for_playlist: list[dict[str, Any]] = []
             artists_processed = 0
             artists_skipped = 0
+            skipped_artists: list[str] = []
 
             async with self.lastfm_client:
                 for artist_name in ordered_unique:
@@ -158,31 +160,23 @@ class PlaylistGeneratorLfmSimilarCommand(BaseCommand):
                     resolved = resolved_by_norm.get(norm)
                     if not resolved:
                         artists_skipped += 1
+                        skipped_artists.append(artist_name)
                         continue
-                    mbid = resolved.mbids[0] if len(resolved.mbids) == 1 else None
-                    top_tracks = await self.lastfm_client.get_top_tracks(
-                        resolved.display_name,
+                    rows, _source = await fetch_top_tracks_for_artist(
+                        resolved,
+                        lastfm_client=self.lastfm_client,
+                        plex_client=self.plex_client,
+                        library_key=library_key,
+                        cached_data=cached_data,
                         limit=top_x,
-                        mbid=mbid,
+                        logger=self.logger,
                     )
-                    added = 0
-                    for t in top_tracks[:top_x]:
-                        track_name = t.get("name", "")
-                        if not track_name:
-                            continue
-                        track_row: dict[str, Any] = {
-                            "artist": resolved.library_artist,
-                            "track": track_name,
-                            "album": t.get("album", ""),
-                        }
-                        if mbid:
-                            track_row["mbid"] = mbid
-                        tracks_for_playlist.append(track_row)
-                        added += 1
-                    if added > 0:
+                    if rows:
+                        tracks_for_playlist.extend(rows)
                         artists_processed += 1
                     else:
                         artists_skipped += 1
+                        skipped_artists.append(resolved.display_name)
 
             if not tracks_for_playlist:
                 self.logger.warning("No tracks found for playlist")
@@ -212,6 +206,7 @@ class PlaylistGeneratorLfmSimilarCommand(BaseCommand):
             self.last_run_stats = {
                 "artists_processed": artists_processed,
                 "artists_skipped": artists_skipped,
+                "skipped_artists": skipped_artists[:20],
                 "artists_invalid": len(invalid_artists),
                 "artists_in_pool": len(pool_names),
                 "artists_valid": len(valid_artists),

--- a/commands/playlist_generator_top_tracks.py
+++ b/commands/playlist_generator_top_tracks.py
@@ -15,6 +15,7 @@ from .command_base import BaseCommand
 from .playlist_generator_helpers import (
     compute_top_tracks_playlist_title,
     delete_playlist_on_target,
+    fetch_top_tracks_for_artist,
     persist_playlist_identity,
     resolve_artist_track_keys,
     resolve_validated_artists,
@@ -105,6 +106,7 @@ class PlaylistGeneratorTopTracksCommand(BaseCommand):
             tracks_for_playlist: list[dict[str, Any]] = []
             artists_processed = 0
             artists_skipped = 0
+            skipped_artists: list[str] = []
 
             if source == "plex":
                 # Plex: get popular tracks via ratingCount
@@ -112,11 +114,19 @@ class PlaylistGeneratorTopTracksCommand(BaseCommand):
                     track_keys = resolve_artist_track_keys(cached_data, resolved)
                     if not track_keys:
                         artists_skipped += 1
+                        skipped_artists.append(resolved.display_name)
+                        self.logger.warning(
+                            "No library tracks found for '%s'", resolved.display_name
+                        )
                         continue
                     first_track_key = track_keys[0]
                     artist_rk = self.plex_client.get_artist_rating_key_from_track(first_track_key)
                     if not artist_rk:
                         artists_skipped += 1
+                        skipped_artists.append(resolved.display_name)
+                        self.logger.warning(
+                            "Could not resolve Plex artist for '%s'", resolved.display_name
+                        )
                         continue
                     popular = self.plex_client.get_artist_popular_tracks(
                         library_key, artist_rk, limit=top_x
@@ -132,39 +142,24 @@ class PlaylistGeneratorTopTracksCommand(BaseCommand):
                         )
                     artists_processed += 1
             else:
-                # Last.fm: get top tracks, pass to sync_playlist for matching
+                # Last.fm with Plex library fallback when chart data is missing
                 async with self.lastfm_client:
                     for resolved in resolved_artists:
-                        mbid = resolved.mbids[0] if len(resolved.mbids) == 1 else None
-                        if mbid:
-                            self.logger.debug(
-                                "Last.fm top tracks for '%s' using Lidarr MBID %s",
-                                resolved.display_name,
-                                mbid,
-                            )
-                        top_tracks = await self.lastfm_client.get_top_tracks(
-                            resolved.display_name,
+                        rows, _source = await fetch_top_tracks_for_artist(
+                            resolved,
+                            lastfm_client=self.lastfm_client,
+                            plex_client=self.plex_client,
+                            library_key=library_key,
+                            cached_data=cached_data,
                             limit=top_x,
-                            mbid=mbid,
+                            logger=self.logger,
                         )
-                        added = 0
-                        for t in top_tracks[:top_x]:
-                            track_name = t.get("name", "")
-                            if not track_name:
-                                continue
-                            track_row: dict[str, Any] = {
-                                "artist": resolved.library_artist,
-                                "track": track_name,
-                                "album": t.get("album", ""),
-                            }
-                            if mbid:
-                                track_row["mbid"] = mbid
-                            tracks_for_playlist.append(track_row)
-                            added += 1
-                        if added > 0:
+                        if rows:
+                            tracks_for_playlist.extend(rows)
                             artists_processed += 1
                         else:
                             artists_skipped += 1
+                            skipped_artists.append(resolved.display_name)
 
             if not tracks_for_playlist:
                 self.logger.warning("No tracks found for playlist")
@@ -195,6 +190,7 @@ class PlaylistGeneratorTopTracksCommand(BaseCommand):
             self.last_run_stats = {
                 "artists_processed": artists_processed,
                 "artists_skipped": artists_skipped,
+                "skipped_artists": skipped_artists[:20],
                 "artists_invalid": len(invalid_artists),
                 "artists_total": artists_total,
                 "invalid_artists": invalid_artists[:10],

--- a/commands/playlist_generator_top_tracks.py
+++ b/commands/playlist_generator_top_tracks.py
@@ -185,12 +185,19 @@ class PlaylistGeneratorTopTracksCommand(BaseCommand):
             success = result.get("success", False)
             found = result.get("found_tracks", 0)
             total = result.get("total_tracks", 0)
+            artist_match_stats = result.get("artist_match_stats") or {}
+            matching_failures = [
+                s["display_name"]
+                for s in artist_match_stats.values()
+                if s.get("in_lidarr") and s.get("expected", 0) > 0 and s.get("matched", 0) == 0
+            ]
 
             artists_total = len(resolved_artists) + len(invalid_artists)
             self.last_run_stats = {
                 "artists_processed": artists_processed,
                 "artists_skipped": artists_skipped,
                 "skipped_artists": skipped_artists[:20],
+                "matching_failures": matching_failures[:20],
                 "artists_invalid": len(invalid_artists),
                 "artists_total": artists_total,
                 "invalid_artists": invalid_artists[:10],

--- a/tests/test_client_plex_track_scoring.py
+++ b/tests/test_client_plex_track_scoring.py
@@ -43,6 +43,9 @@ def plex_client():
     """Bare instance — only scoring helpers are exercised (no __init__ / API)."""
     c = PlexClient.__new__(PlexClient)
     c.logger = logging.getLogger("test.plex_track_scoring")
+    c.cache_client = None
+    c._record_cache_hit = lambda: None
+    c._record_cache_miss = lambda: None
     return c
 
 
@@ -119,6 +122,42 @@ def test_score_track_match_optimized_gore_period_matches_library(plex_client: Pl
     assert total >= 100
 
 
+def test_search_for_track_escalating_prefers_exact_over_normalized(plex_client: PlexClient):
+    from utils.text_normalizer import normalize_text
+
+    cached = {
+        "tracks": [
+            {
+                "key": "1",
+                "title": "pray",
+                "artist": "gore.",
+                "album": "a",
+                "artist_guid": "",
+            },
+            {
+                "key": "2",
+                "title": "mean man's dream",
+                "artist": "gore",
+                "album": "b",
+                "artist_guid": "",
+            },
+        ],
+        "artist_index": {normalize_text("gore."): ["1", "2"]},
+        "track_index": {normalize_text("pray"): ["1"], normalize_text("mean man's dream"): ["2"]},
+        "mbid_index": {},
+    }
+    plex_client.config = {"LIBRARY_CACHE_PLEX_ENABLED": True}
+    ctx = {
+        "display_name": "Gore.",
+        "library_artist": "gore.",
+        "norm": normalize_text("gore."),
+        "mbids": ["mbid-1"],
+        "in_lidarr": True,
+    }
+    result = plex_client.search_for_track_escalating("Pray", ctx, cached_data=cached)
+    assert result == "1"
+
+
 def test_search_cached_library_gore_period_not_wrong_gore(plex_client: PlexClient):
     from utils.text_normalizer import normalize_text
 
@@ -146,6 +185,6 @@ def test_search_cached_library_gore_period_not_wrong_gore(plex_client: PlexClien
         },
         "mbid_index": {},
     }
-    plex_client.config = type("Cfg", (), {"LIBRARY_CACHE_PLEX_ENABLED": True})()
+    plex_client.config = {"LIBRARY_CACHE_PLEX_ENABLED": True}
     result = plex_client.search_cached_library("Mean Man's Dream", "Gore.", cached)
     assert result == "1"

--- a/tests/test_client_plex_track_scoring.py
+++ b/tests/test_client_plex_track_scoring.py
@@ -117,3 +117,35 @@ def test_score_track_match_optimized_gore_period_matches_library(plex_client: Pl
     assert artist_s == 100
     assert track_s == 100
     assert total >= 100
+
+
+def test_search_cached_library_gore_period_not_wrong_gore(plex_client: PlexClient):
+    from utils.text_normalizer import normalize_text
+
+    cached = {
+        "tracks": [
+            {
+                "key": "1",
+                "title": "mean man's dream",
+                "artist": "gore.",
+                "album": "a",
+                "artist_guid": "",
+            },
+            {
+                "key": "2",
+                "title": "other song",
+                "artist": "gore",
+                "album": "b",
+                "artist_guid": "",
+            },
+        ],
+        "artist_index": {"gore": ["1", "2"]},
+        "track_index": {
+            normalize_text("mean man's dream"): ["1"],
+            normalize_text("other song"): ["2"],
+        },
+        "mbid_index": {},
+    }
+    plex_client.config = type("Cfg", (), {"LIBRARY_CACHE_PLEX_ENABLED": True})()
+    result = plex_client.search_cached_library("Mean Man's Dream", "Gore.", cached)
+    assert result == "1"

--- a/tests/test_lastfm_top_tracks_mbid.py
+++ b/tests/test_lastfm_top_tracks_mbid.py
@@ -1,4 +1,4 @@
-"""Tests for Last.fm top tracks MBID parameter."""
+"""Tests for Last.fm top tracks MBID parameter and fallback."""
 
 import pytest
 
@@ -38,3 +38,52 @@ async def test_get_top_tracks_uses_mbid_param(lastfm_client, monkeypatch):
     assert "artist" not in captured["params"]
     assert len(tracks) == 1
     assert tracks[0]["name"] == "Song"
+
+
+@pytest.mark.asyncio
+async def test_get_top_tracks_mbid_empty_falls_back_to_name(lastfm_client, monkeypatch):
+    calls: list[dict] = []
+
+    async def fake_request(params, context_info=""):
+        calls.append(dict(params))
+        if "mbid" in params:
+            return {"toptracks": {"track": []}}
+        return {
+            "toptracks": {
+                "track": [
+                    {"name": "Mean Man's Dream", "artist": {"name": "Gore."}, "playcount": "5"}
+                ]
+            }
+        }
+
+    monkeypatch.setattr(lastfm_client, "_make_request", fake_request)
+    tracks = await lastfm_client.get_top_tracks(
+        "Gore.", limit=5, mbid="f5d4e4ae-90b8-4b30-aa74-a9bf36170bd4"
+    )
+    assert len(calls) == 2
+    assert "mbid" in calls[0]
+    assert calls[1]["artist"] == "Gore."
+    assert len(tracks) == 1
+    assert tracks[0]["name"] == "Mean Man's Dream"
+
+
+@pytest.mark.asyncio
+async def test_get_top_tracks_mbid_failure_falls_back_to_name(lastfm_client, monkeypatch):
+    calls: list[dict] = []
+
+    async def fake_request(params, context_info=""):
+        calls.append(dict(params))
+        if "mbid" in params:
+            return None
+        return {
+            "toptracks": {
+                "track": [{"name": "Song", "artist": {"name": "Gore."}, "playcount": "1"}]
+            }
+        }
+
+    monkeypatch.setattr(lastfm_client, "_make_request", fake_request)
+    tracks = await lastfm_client.get_top_tracks(
+        "Gore.", limit=5, mbid="f5d4e4ae-90b8-4b30-aa74-a9bf36170bd4"
+    )
+    assert len(calls) == 2
+    assert len(tracks) == 1

--- a/tests/test_lastfm_top_tracks_mbid.py
+++ b/tests/test_lastfm_top_tracks_mbid.py
@@ -68,6 +68,30 @@ async def test_get_top_tracks_mbid_empty_falls_back_to_name(lastfm_client, monke
 
 
 @pytest.mark.asyncio
+async def test_get_top_tracks_mbid_error_falls_back_to_name(lastfm_client, monkeypatch):
+    calls: list[dict] = []
+
+    async def fake_request(params, context_info=""):
+        calls.append(dict(params))
+        if "mbid" in params:
+            return {"error": 6, "message": "The artist you supplied could not be found"}
+        return {
+            "toptracks": {
+                "track": [{"name": "Pray", "artist": {"name": "gore."}, "playcount": "5"}]
+            }
+        }
+
+    monkeypatch.setattr(lastfm_client, "_make_request", fake_request)
+    tracks = await lastfm_client.get_top_tracks(
+        "Gore.", limit=5, mbid="f5d4e4ae-90b8-4b30-aa74-a9bf36170bd4"
+    )
+    assert len(calls) == 2
+    assert calls[1]["artist"] == "Gore."
+    assert len(tracks) == 1
+    assert tracks[0]["name"] == "Pray"
+
+
+@pytest.mark.asyncio
 async def test_get_top_tracks_mbid_failure_falls_back_to_name(lastfm_client, monkeypatch):
     calls: list[dict] = []
 

--- a/tests/test_playlist_artist_resolution.py
+++ b/tests/test_playlist_artist_resolution.py
@@ -77,7 +77,7 @@ def test_resolve_validated_artists_dedupes_duplicate_norms():
 
 
 @pytest.mark.asyncio
-async def test_fetch_top_tracks_for_artist_prefers_lastfm_name_over_mbid():
+async def test_fetch_top_tracks_for_artist_tries_mbid_then_exact_name():
     from commands.playlist_generator_helpers import fetch_top_tracks_for_artist
 
     class FakeLastFM:
@@ -108,11 +108,12 @@ async def test_fetch_top_tracks_for_artist_prefers_lastfm_name_over_mbid():
         limit=5,
         logger=logger,
     )
-    assert source == "lastfm"
+    assert source == "lastfm_exact"
     assert len(rows) == 1
     assert rows[0]["track"] == "Pray"
-    assert FakeLastFM.calls[0] == ("Gore.", None)
-    assert all(call[1] is None for call in FakeLastFM.calls)
+    assert "match_context" in rows[0]
+    assert FakeLastFM.calls[0][1] == "f5d4e4ae-90b8-4b30-aa74-a9bf36170bd4"
+    assert FakeLastFM.calls[1] == ("Gore.", None)
 
 
 @pytest.mark.asyncio
@@ -124,6 +125,11 @@ async def test_fetch_top_tracks_for_artist_plex_fallback():
             return []
 
     class FakePlex:
+        def search_for_track_escalating(
+            self, track_name, match_context, cached_data=None, album_name=""
+        ):
+            return None
+
         def get_artist_rating_key_from_track(self, track_key):
             return "artist-1"
 

--- a/tests/test_playlist_artist_resolution.py
+++ b/tests/test_playlist_artist_resolution.py
@@ -1,5 +1,7 @@
 """Tests for playlist artist resolution helpers."""
 
+import pytest
+
 from commands.playlist_generator_helpers import (
     ResolvedArtist,
     resolve_artist_track_keys,
@@ -49,3 +51,70 @@ def test_resolve_artist_track_keys_filters_wrong_gore():
     )
     keys = resolve_artist_track_keys(cached, resolved)
     assert keys == ["1"]
+
+
+def test_resolve_validated_artists_dedupes_duplicate_norms():
+    plot_norm = normalize_text("the plot in you")
+    cached = {
+        "tracks": [
+            {"key": "1", "artist": "gore.", "title": "a", "album": "", "artist_guid": ""},
+            {"key": "2", "artist": "the plot in you", "title": "b", "album": "", "artist_guid": ""},
+        ],
+        "artist_index": {normalize_text("gore."): ["1"], plot_norm: ["2"]},
+        "track_index": {},
+        "mbid_index": {},
+    }
+    lidarr_pairs = [("Gore.", "f5d4e4ae-90b8-4b30-aa74-a9bf36170bd4")]
+    resolved, invalid = resolve_validated_artists(
+        ["The Plot In You", "The Plot in You", "Gore."],
+        cached,
+        lidarr_pairs=lidarr_pairs,
+    )
+    assert invalid == []
+    assert len(resolved) == 2
+    assert resolved[0].display_name == "The Plot In You"
+    assert resolved[1].display_name == "Gore."
+
+
+@pytest.mark.asyncio
+async def test_fetch_top_tracks_for_artist_plex_fallback():
+    from commands.playlist_generator_helpers import fetch_top_tracks_for_artist
+
+    class FakeLastFM:
+        async def get_top_tracks(self, artist_name, limit=10, *, mbid=None):
+            return []
+
+    class FakePlex:
+        def get_artist_rating_key_from_track(self, track_key):
+            return "artist-1"
+
+        def get_artist_popular_tracks(self, library_key, artist_rk, limit=10):
+            return [
+                {
+                    "key": "99",
+                    "title": "Mean Man's Dream",
+                    "artist": "gore.",
+                    "album": "Album",
+                }
+            ]
+
+    resolved = ResolvedArtist(
+        display_name="Gore.",
+        norm=normalize_text("gore."),
+        mbids=["f5d4e4ae-90b8-4b30-aa74-a9bf36170bd4"],
+        library_artist="gore.",
+    )
+    logger = __import__("logging").getLogger("test.fetch")
+    rows, source = await fetch_top_tracks_for_artist(
+        resolved,
+        lastfm_client=FakeLastFM(),
+        plex_client=FakePlex(),
+        library_key="7",
+        cached_data=_cache_with_gore_artists(),
+        limit=5,
+        logger=logger,
+    )
+    assert source == "plex"
+    assert len(rows) == 1
+    assert rows[0]["rating_key"] == "99"
+    assert rows[0]["track"] == "Mean Man's Dream"

--- a/tests/test_playlist_artist_resolution.py
+++ b/tests/test_playlist_artist_resolution.py
@@ -77,6 +77,45 @@ def test_resolve_validated_artists_dedupes_duplicate_norms():
 
 
 @pytest.mark.asyncio
+async def test_fetch_top_tracks_for_artist_prefers_lastfm_name_over_mbid():
+    from commands.playlist_generator_helpers import fetch_top_tracks_for_artist
+
+    class FakeLastFM:
+        calls: list[tuple[str | None, str | None]] = []
+
+        async def get_top_tracks(self, artist_name, limit=10, *, mbid=None):
+            FakeLastFM.calls.append((artist_name, mbid))
+            if mbid:
+                return []
+            if artist_name == "Gore.":
+                return [{"name": "Pray", "artist": "gore."}]
+            return []
+
+    resolved = ResolvedArtist(
+        display_name="Gore.",
+        norm=normalize_text("gore."),
+        mbids=["f5d4e4ae-90b8-4b30-aa74-a9bf36170bd4"],
+        library_artist="gore.",
+    )
+    logger = __import__("logging").getLogger("test.fetch")
+    FakeLastFM.calls = []
+    rows, source = await fetch_top_tracks_for_artist(
+        resolved,
+        lastfm_client=FakeLastFM(),
+        plex_client=None,
+        library_key=None,
+        cached_data=_cache_with_gore_artists(),
+        limit=5,
+        logger=logger,
+    )
+    assert source == "lastfm"
+    assert len(rows) == 1
+    assert rows[0]["track"] == "Pray"
+    assert FakeLastFM.calls[0] == ("Gore.", None)
+    assert all(call[1] is None for call in FakeLastFM.calls)
+
+
+@pytest.mark.asyncio
 async def test_fetch_top_tracks_for_artist_plex_fallback():
     from commands.playlist_generator_helpers import fetch_top_tracks_for_artist
 

--- a/tests/test_playlist_match_strategy.py
+++ b/tests/test_playlist_match_strategy.py
@@ -1,0 +1,42 @@
+"""Tests for Last.fm / Plex lookup ordering and validation helpers."""
+
+from utils.text_normalizer import normalize_text
+from utils.track_match import lastfm_query_plan, lastfm_tracks_match_artist, plex_search_variants
+
+
+def test_lastfm_query_plan_mbid_then_exact_then_normalized():
+    plan = lastfm_query_plan("Gore.", "gore.", normalize_text("gore."), ["mbid-1"])
+    labels = [label for _, _, label in plan]
+    assert labels[0] == "mbid"
+    assert "exact" in labels
+    assert labels.index("mbid") < labels.index("exact")
+
+
+def test_lastfm_query_plan_skips_redundant_normalized_when_exact_covers_norm():
+    norm = normalize_text("landmvrks")
+    plan = lastfm_query_plan("LANDMVRKS", "landmvrks", norm, [])
+    labels = [label for _, _, label in plan]
+    assert labels == ["exact"]
+    assert "normalized" not in labels
+
+
+def test_plex_search_variants_order():
+    ctx = {
+        "display_name": "Gore.",
+        "library_artist": "gore.",
+        "norm": normalize_text("gore."),
+        "mbids": ["mbid-1"],
+        "in_lidarr": True,
+    }
+    variants = plex_search_variants(ctx)
+    labels = [label for _, _, label in variants]
+    assert labels[0].startswith("mbid")
+    assert "exact" in labels
+    assert labels.index("mbid_exact") < labels.index("exact")
+
+
+def test_lastfm_tracks_match_artist_rejects_wrong_gore():
+    tracks = [{"name": "Mean Man's Dream", "artist": "gore"}]
+    assert not lastfm_tracks_match_artist(tracks, "Gore.", "gore.")
+    tracks_ok = [{"name": "Pray", "artist": "gore."}]
+    assert lastfm_tracks_match_artist(tracks_ok, "Gore.", "gore.")

--- a/utils/track_match.py
+++ b/utils/track_match.py
@@ -9,6 +9,7 @@ names (e.g. grandparentTitle vs AlbumArtist), cache record shape, and auth/HTTP 
 from __future__ import annotations
 
 import re
+from typing import Any
 
 # Subtracted from total score when Plex/Jellyfin credits collaborators but the source does not.
 # Large enough that album bonuses (+50) cannot flip the winner vs the primary-artist line.
@@ -181,6 +182,100 @@ def artist_identity_matches(source: str, library: str) -> bool:
             return False
         return True
     return True
+
+
+def lastfm_exact_name_candidates(display_name: str, library_artist: str) -> list[str]:
+    """Distinct Last.fm artist names preserving punctuation."""
+    seen_lower: set[str] = set()
+    names: list[str] = []
+    for raw in (display_name, library_artist):
+        name = (raw or "").strip()
+        key = name.lower()
+        if name and key not in seen_lower:
+            seen_lower.add(key)
+            names.append(name)
+    return names
+
+
+def lastfm_query_plan(
+    display_name: str,
+    library_artist: str,
+    norm: str,
+    mbids: list[str],
+) -> list[tuple[str, str | None, str]]:
+    """Last.fm lookup order: MBID, exact names, normalized name (last resort)."""
+    from utils.text_normalizer import normalize_text
+
+    plan: list[tuple[str, str | None, str]] = []
+    mbid = mbids[0] if len(mbids) == 1 else None
+    exact = lastfm_exact_name_candidates(display_name, library_artist)
+
+    if mbid:
+        plan.append((display_name or (exact[0] if exact else ""), mbid, "mbid"))
+
+    for name in exact:
+        plan.append((name, None, "exact"))
+
+    norm_key = (norm or "").strip()
+    if norm_key:
+        exact_norms = {normalize_text(n) for n in exact}
+        if norm_key not in exact_norms:
+            plan.append((norm_key, None, "normalized"))
+
+    return plan
+
+
+def plex_search_variants(match_context: dict[str, Any]) -> list[tuple[str, list[str] | None, str]]:
+    """Plex track search order: MBID + exact names, exact names, normalized (last)."""
+    from utils.text_normalizer import normalize_text
+
+    display = (match_context.get("display_name") or "").strip()
+    library = (match_context.get("library_artist") or "").strip()
+    norm = (match_context.get("norm") or "").strip()
+    mbids_raw = match_context.get("mbids") or []
+    mbid_list = [m for m in mbids_raw if (m or "").strip()] or None
+
+    exact = lastfm_exact_name_candidates(display, library)
+    variants: list[tuple[str, list[str] | None, str]] = []
+    seen: set[tuple[str, str | None]] = set()
+
+    def add(name: str, mbids: list[str] | None, label: str) -> None:
+        name = (name or "").strip()
+        if not name:
+            return
+        mb_key = tuple(mbids) if mbids else None
+        key = (name.lower(), mb_key)
+        if key in seen:
+            return
+        seen.add(key)
+        variants.append((name, mbids, label))
+
+    if mbid_list:
+        for name in exact:
+            add(name, mbid_list, "mbid_exact")
+
+    for name in exact:
+        add(name, None, "exact")
+
+    if norm:
+        exact_norms = {normalize_text(n) for n in exact}
+        if norm not in exact_norms:
+            add(norm, None, "normalized")
+
+    return variants
+
+
+def lastfm_tracks_match_artist(
+    tracks: list[dict[str, Any]], display_name: str, library_artist: str
+) -> bool:
+    """True if any Last.fm row artist string matches the expected identity."""
+    for track in tracks:
+        lfm_artist = (track.get("artist") or "").strip()
+        if artist_identity_matches(display_name, lfm_artist):
+            return True
+        if library_artist and artist_identity_matches(library_artist, lfm_artist):
+            return True
+    return False
 
 
 def normalized_artist_for_source_vs_library(


### PR DESCRIPTION
Add Last.fm MBID-to-name fallback, Plex library popular-track fallback, skip logging, duplicate artist dedupe, and always-apply cache identity filtering.