### PR TITLE
Resolve Plex tracks once during fetch and stop deleting playlists on …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - N/A
 
 ### Fixes
-- **Playlist matching**: Artist Essentials and related playlist commands disambiguate short punctuation-sensitive names (e.g. `Gore.` vs `gore`) using Lidarr MBIDs and strict artist identity checks so Last.fm and Plex lookups target the correct band.
-- **Artist Essentials**: Last.fm lookup order is MBID → exact artist name (punctuation preserved) → normalized fallback; Lidarr artists validate fetched tracks against Plex before use, Plex sync escalates artist matching the same way, and logs a warning when 0/N tracks match for a library artist.
+- **Artist Essentials & playlist matching**: Disambiguate punctuation-sensitive artist names (e.g. `Gore.` vs `gore`) via Lidarr MBIDs and strict Plex identity checks; Last.fm lookup tries MBID → exact name → normalized fallback with Plex validation before accepting results; resolve Plex track keys once during fetch (parallel Last.fm requests) instead of re-matching at sync; log when 0/N tracks match for a library artist; do not delete target playlists when saving command settings (only on run when the title changes, or when deleting the command).
 
 ### Housekeeping
 - **Docker**: Drop Debian-based runtime image; Wolfi/Chainguard (`Dockerfile`, digest-pinned Python 3.14) is now the sole published image. Develop publishes `:develop`; releases publish `latest`, `v0`, `v0.3`, and patch tags only (no `-wolfi` suffix or Debian fallback).

--- a/app/api/commands.py
+++ b/app/api/commands.py
@@ -345,71 +345,27 @@ async def update_command(
         if request.timeout_minutes is not None:
             command.timeout_minutes = request.timeout_minutes
         if request.config_json is not None:
-            prev_config_snapshot = dict(command.config_json or {})
             command.config_json = request.config_json
-            # Playlist generators: keep display_name in sync with playlist title on save; delete prior
-            # playlist on Plex/Jellyfin when title or target changes so orphans are not left behind.
+            # Playlist generators: keep display_name in sync with playlist title on save.
             if command_name.startswith("lfm_similar_"):
                 from commands.playlist_generator_helpers import compute_lfm_similar_playlist_title
-                from services.command_cleanup import CommandCleanupService
 
                 merged = dict(command.config_json or {})
-                new_title = compute_lfm_similar_playlist_title(merged)
-                old_last = prev_config_snapshot.get("last_playlist_title")
-                old_target = str(prev_config_snapshot.get("target", "plex")).lower()
-                new_target = str(merged.get("target", "plex")).lower()
-                if old_last and (old_last != new_title or old_target != new_target):
-                    CommandCleanupService()._delete_playlist_if_exists(
-                        old_target,
-                        old_last,
-                        playlist_id=prev_config_snapshot.get("last_playlist_id"),
-                    )
-                    merged.pop("last_playlist_title", None)
-                    merged.pop("last_playlist_id", None)
-                    command.config_json = merged
-                command.display_name = new_title
+                command.display_name = compute_lfm_similar_playlist_title(merged)
             elif command_name.startswith("top_tracks_"):
                 from commands.playlist_generator_helpers import (
                     compute_top_tracks_playlist_title_from_config,
                 )
-                from services.command_cleanup import CommandCleanupService
 
                 merged = dict(command.config_json or {})
-                new_title = compute_top_tracks_playlist_title_from_config(merged)
-                old_last = prev_config_snapshot.get("last_playlist_title")
-                old_target = str(prev_config_snapshot.get("target", "plex")).lower()
-                new_target = str(merged.get("target", "plex")).lower()
-                if old_last and (old_last != new_title or old_target != new_target):
-                    CommandCleanupService()._delete_playlist_if_exists(
-                        old_target,
-                        old_last,
-                        playlist_id=prev_config_snapshot.get("last_playlist_id"),
-                    )
-                    merged.pop("last_playlist_title", None)
-                    merged.pop("last_playlist_id", None)
-                    command.config_json = merged
-                command.display_name = new_title
+                command.display_name = compute_top_tracks_playlist_title_from_config(merged)
             elif command_name.startswith("setlistfm_"):
                 from commands.playlist_generator_helpers import (
                     compute_setlistfm_playlist_title_from_config,
                 )
-                from services.command_cleanup import CommandCleanupService
 
                 merged = dict(command.config_json or {})
-                new_title = compute_setlistfm_playlist_title_from_config(merged)
-                old_last = prev_config_snapshot.get("last_playlist_title")
-                old_target = str(prev_config_snapshot.get("target", "plex")).lower()
-                new_target = str(merged.get("target", "plex")).lower()
-                if old_last and (old_last != new_title or old_target != new_target):
-                    CommandCleanupService()._delete_playlist_if_exists(
-                        old_target,
-                        old_last,
-                        playlist_id=prev_config_snapshot.get("last_playlist_id"),
-                    )
-                    merged.pop("last_playlist_title", None)
-                    merged.pop("last_playlist_id", None)
-                    command.config_json = merged
-                command.display_name = new_title
+                command.display_name = compute_setlistfm_playlist_title_from_config(merged)
             # display_name for daylist/local_discovery: sync when plex_history_account_id changes
             elif command_name.startswith("daylist_") or command_name.startswith("local_discovery_"):
                 plex_account_id = request.config_json.get("plex_history_account_id")

--- a/commands/playlist_generator_helpers.py
+++ b/commands/playlist_generator_helpers.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Shared helpers for playlist generator commands (Artist Essentials, Last.fm Similar, etc.)."""
 
+import asyncio
 from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -14,6 +15,7 @@ from utils.track_match import (
     lastfm_tracks_match_artist,
 )
 
+DEFAULT_LASTFM_FETCH_CONCURRENCY = 8
 SEP = " · "
 MAX_ARTIST_LEN = 40
 PLAYLIST_TITLE_TOP_TRACKS_PREFIX = "[Cmdarr] Artist Essentials"
@@ -308,29 +310,32 @@ def _plex_popular_rows_for_resolved(
     return rows
 
 
-def _probe_tracks_match_library(
+def _resolve_tracks_in_library(
     track_rows: list[dict[str, Any]],
     resolved: ResolvedArtist,
     plex_client: Any,
     cached_data: dict[str, Any] | None,
-) -> int:
-    """Return how many track titles resolve in Plex using escalating artist search."""
+) -> list[dict[str, Any]]:
+    """Resolve Plex rating keys once per track row (used by fetch and sync)."""
     if not plex_client or not cached_data or not track_rows:
-        return 0
+        return track_rows
     ctx = artist_match_context(resolved)
-    matched = 0
+    resolved_rows: list[dict[str, Any]] = []
     for row in track_rows:
-        track_name = (row.get("track") or "").strip()
-        if not track_name:
-            continue
-        if plex_client.search_for_track_escalating(
-            track_name,
-            ctx,
-            cached_data=cached_data,
-            album_name=row.get("album", ""),
-        ):
-            matched += 1
-    return matched
+        enriched = dict(row)
+        if not enriched.get("rating_key"):
+            track_name = (row.get("track") or "").strip()
+            if track_name:
+                rating_key = plex_client.search_for_track_escalating(
+                    track_name,
+                    ctx,
+                    cached_data=cached_data,
+                    album_name=row.get("album", ""),
+                )
+                if rating_key:
+                    enriched["rating_key"] = rating_key
+        resolved_rows.append(enriched)
+    return resolved_rows
 
 
 async def fetch_top_tracks_for_artist(
@@ -367,7 +372,8 @@ async def fetch_top_tracks_for_artist(
 
         rows = _lastfm_rows_for_resolved(resolved, lastfm_tracks, limit)
         if resolved.mbids and plex_client and cached_data:
-            matched = _probe_tracks_match_library(rows, resolved, plex_client, cached_data)
+            rows = _resolve_tracks_in_library(rows, resolved, plex_client, cached_data)
+            matched = sum(1 for row in rows if row.get("rating_key"))
             if matched == 0:
                 logger.warning(
                     "Last.fm returned %s tracks for '%s' (%s) but none matched Plex; trying next source",
@@ -378,7 +384,7 @@ async def fetch_top_tracks_for_artist(
                 continue
             if matched < len(rows):
                 logger.info(
-                    "Last.fm '%s': %s/%s tracks verified in Plex library",
+                    "Last.fm '%s': %s/%s tracks resolved in Plex library",
                     resolved.display_name,
                     matched,
                     len(rows),
@@ -404,6 +410,37 @@ async def fetch_top_tracks_for_artist(
         ", ".join(tried) or "nothing",
     )
     return [], "none"
+
+
+async def fetch_top_tracks_for_artists_parallel(
+    resolved_artists: list[ResolvedArtist],
+    *,
+    lastfm_client: Any,
+    plex_client: Any | None,
+    library_key: str | None,
+    cached_data: dict[str, Any] | None,
+    limit: int,
+    logger: Any,
+    concurrency: int = DEFAULT_LASTFM_FETCH_CONCURRENCY,
+) -> list[tuple[list[dict[str, Any]], str]]:
+    """Fetch top tracks for many artists concurrently (Last.fm rate limit still applies)."""
+    if not resolved_artists:
+        return []
+    sem = asyncio.Semaphore(max(1, concurrency))
+
+    async def _fetch(resolved: ResolvedArtist) -> tuple[list[dict[str, Any]], str]:
+        async with sem:
+            return await fetch_top_tracks_for_artist(
+                resolved,
+                lastfm_client=lastfm_client,
+                plex_client=plex_client,
+                library_key=library_key,
+                cached_data=cached_data,
+                limit=limit,
+                logger=logger,
+            )
+
+    return list(await asyncio.gather(*[_fetch(resolved) for resolved in resolved_artists]))
 
 
 def load_lidarr_artist_norm_mbid_index_sync() -> dict[str, list[str]]:

--- a/commands/playlist_generator_lfm_similar.py
+++ b/commands/playlist_generator_lfm_similar.py
@@ -16,7 +16,7 @@ from .playlist_generator_helpers import (
     build_lfm_similar_artist_pool,
     compute_lfm_similar_playlist_title,
     delete_playlist_on_target,
-    fetch_top_tracks_for_artist,
+    fetch_top_tracks_for_artists_parallel,
     persist_playlist_identity,
     resolve_validated_artists,
     validate_artists_against_cache,
@@ -153,24 +153,28 @@ class PlaylistGeneratorLfmSimilarCommand(BaseCommand):
             artists_processed = 0
             artists_skipped = 0
             skipped_artists: list[str] = []
+            resolved_to_fetch: list[Any] = []
+
+            for artist_name in ordered_unique:
+                norm = normalize_text(artist_name.lower())
+                resolved = resolved_by_norm.get(norm)
+                if not resolved:
+                    artists_skipped += 1
+                    skipped_artists.append(artist_name)
+                    continue
+                resolved_to_fetch.append(resolved)
 
             async with self.lastfm_client:
-                for artist_name in ordered_unique:
-                    norm = normalize_text(artist_name.lower())
-                    resolved = resolved_by_norm.get(norm)
-                    if not resolved:
-                        artists_skipped += 1
-                        skipped_artists.append(artist_name)
-                        continue
-                    rows, _source = await fetch_top_tracks_for_artist(
-                        resolved,
-                        lastfm_client=self.lastfm_client,
-                        plex_client=self.plex_client,
-                        library_key=library_key,
-                        cached_data=cached_data,
-                        limit=top_x,
-                        logger=self.logger,
-                    )
+                results = await fetch_top_tracks_for_artists_parallel(
+                    resolved_to_fetch,
+                    lastfm_client=self.lastfm_client,
+                    plex_client=self.plex_client,
+                    library_key=library_key,
+                    cached_data=cached_data,
+                    limit=top_x,
+                    logger=self.logger,
+                )
+                for resolved, (rows, _source) in zip(resolved_to_fetch, results, strict=True):
                     if rows:
                         tracks_for_playlist.extend(rows)
                         artists_processed += 1

--- a/commands/playlist_generator_top_tracks.py
+++ b/commands/playlist_generator_top_tracks.py
@@ -15,7 +15,7 @@ from .command_base import BaseCommand
 from .playlist_generator_helpers import (
     compute_top_tracks_playlist_title,
     delete_playlist_on_target,
-    fetch_top_tracks_for_artist,
+    fetch_top_tracks_for_artists_parallel,
     persist_playlist_identity,
     resolve_artist_track_keys,
     resolve_validated_artists,
@@ -144,16 +144,16 @@ class PlaylistGeneratorTopTracksCommand(BaseCommand):
             else:
                 # Last.fm with Plex library fallback when chart data is missing
                 async with self.lastfm_client:
-                    for resolved in resolved_artists:
-                        rows, _source = await fetch_top_tracks_for_artist(
-                            resolved,
-                            lastfm_client=self.lastfm_client,
-                            plex_client=self.plex_client,
-                            library_key=library_key,
-                            cached_data=cached_data,
-                            limit=top_x,
-                            logger=self.logger,
-                        )
+                    results = await fetch_top_tracks_for_artists_parallel(
+                        resolved_artists,
+                        lastfm_client=self.lastfm_client,
+                        plex_client=self.plex_client,
+                        library_key=library_key,
+                        cached_data=cached_data,
+                        limit=top_x,
+                        logger=self.logger,
+                    )
+                    for resolved, (rows, _source) in zip(resolved_artists, results, strict=True):
                         if rows:
                             tracks_for_playlist.extend(rows)
                             artists_processed += 1

--- a/tests/test_command_update_playlist.py
+++ b/tests/test_command_update_playlist.py
@@ -1,0 +1,69 @@
+"""Ensure command config updates do not delete playlists on the target."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.api.commands import CommandUpdateRequest, update_command
+from database.config_models import CommandConfig, ConfigBase
+
+
+@pytest.fixture()
+def db_session():
+    engine = create_engine("sqlite://")
+    ConfigBase.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine)
+    db = TestSession()
+    try:
+        db.add(
+            CommandConfig(
+                command_name="top_tracks_00001",
+                display_name="[Cmdarr] Artist Essentials: A · B",
+                enabled=True,
+                config_json={
+                    "artists": ["Dead Air Divine", "LANDMVRKS"],
+                    "top_x": 5,
+                    "source": "lastfm",
+                    "target": "plex",
+                    "last_playlist_title": "[Cmdarr] Artist Essentials: Dead Air Divine · LANDMVRKS",
+                    "last_playlist_id": "585934",
+                },
+            )
+        )
+        db.commit()
+        yield db
+    finally:
+        db.close()
+        engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_update_command_does_not_delete_playlist_when_source_changes(db_session):
+    with patch(
+        "services.command_cleanup.CommandCleanupService._delete_playlist_if_exists"
+    ) as delete_mock:
+        request = CommandUpdateRequest(
+            config_json={
+                "artists": ["Dead Air Divine", "LANDMVRKS"],
+                "top_x": 5,
+                "source": "plex",
+                "target": "plex",
+                "last_playlist_title": "[Cmdarr] Artist Essentials: Dead Air Divine · LANDMVRKS",
+                "last_playlist_id": "585934",
+            }
+        )
+        await update_command("top_tracks_00001", request, db_session)
+
+        delete_mock.assert_not_called()
+        updated = (
+            db_session.query(CommandConfig)
+            .filter(CommandConfig.command_name == "top_tracks_00001")
+            .one()
+        )
+        assert updated.config_json["source"] == "plex"
+        assert updated.config_json["last_playlist_id"] == "585934"
+        assert updated.config_json["last_playlist_title"].startswith("[Cmdarr] Artist Essentials")

--- a/tests/test_playlist_artist_resolution.py
+++ b/tests/test_playlist_artist_resolution.py
@@ -163,3 +163,87 @@ async def test_fetch_top_tracks_for_artist_plex_fallback():
     assert len(rows) == 1
     assert rows[0]["rating_key"] == "99"
     assert rows[0]["track"] == "Mean Man's Dream"
+
+
+@pytest.mark.asyncio
+async def test_fetch_top_tracks_for_artist_attaches_rating_keys_from_lastfm():
+    from commands.playlist_generator_helpers import fetch_top_tracks_for_artist
+
+    class FakeLastFM:
+        async def get_top_tracks(self, artist_name, limit=10, *, mbid=None):
+            if mbid:
+                return []
+            if artist_name == "Gore.":
+                return [
+                    {"name": "Pray", "artist": "gore.", "album": "A"},
+                    {"name": "Wrath", "artist": "gore.", "album": "A"},
+                ]
+            return []
+
+    class FakePlex:
+        def __init__(self):
+            self.search_calls = 0
+
+        def search_for_track_escalating(
+            self, track_name, match_context, cached_data=None, album_name=""
+        ):
+            self.search_calls += 1
+            return {"Pray": "101", "Wrath": "102"}.get(track_name)
+
+    resolved = ResolvedArtist(
+        display_name="Gore.",
+        norm=normalize_text("gore."),
+        mbids=["f5d4e4ae-90b8-4b30-aa74-a9bf36170bd4"],
+        library_artist="gore.",
+    )
+    plex = FakePlex()
+    logger = __import__("logging").getLogger("test.fetch")
+    rows, source = await fetch_top_tracks_for_artist(
+        resolved,
+        lastfm_client=FakeLastFM(),
+        plex_client=plex,
+        library_key="7",
+        cached_data=_cache_with_gore_artists(),
+        limit=5,
+        logger=logger,
+    )
+    assert source == "lastfm_exact"
+    assert len(rows) == 2
+    assert rows[0]["rating_key"] == "101"
+    assert rows[1]["rating_key"] == "102"
+    assert plex.search_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_fetch_top_tracks_for_artists_parallel_preserves_order():
+    from commands.playlist_generator_helpers import fetch_top_tracks_for_artists_parallel
+
+    class FakeLastFM:
+        async def get_top_tracks(self, artist_name, limit=10, *, mbid=None):
+            return [{"name": f"Track-{artist_name}", "artist": artist_name}]
+
+    resolved_a = ResolvedArtist(
+        display_name="A",
+        norm=normalize_text("a"),
+        mbids=[],
+        library_artist="a",
+    )
+    resolved_b = ResolvedArtist(
+        display_name="B",
+        norm=normalize_text("b"),
+        mbids=[],
+        library_artist="b",
+    )
+    logger = __import__("logging").getLogger("test.parallel")
+    results = await fetch_top_tracks_for_artists_parallel(
+        [resolved_a, resolved_b],
+        lastfm_client=FakeLastFM(),
+        plex_client=None,
+        library_key=None,
+        cached_data=None,
+        limit=1,
+        logger=logger,
+    )
+    assert len(results) == 2
+    assert results[0][0][0]["track"] == "Track-A"
+    assert results[1][0][0]["track"] == "Track-B"


### PR DESCRIPTION
Parallel Last.fm fetches and pre-resolved rating keys avoid duplicate Plex lookups at sync time; saving command settings no longer deletes target playlists.