### PR TITLE
Fix playlist artist discovery on empty Plex syncs and cap MB lookups.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - N/A
 
 ### Fixes
+- **Playlist artist discovery**: Run discovery on 0-match Plex syncs by including `unmatched_tracks` in `skipped_empty` results; apply `artist_discovery_max_per_run` before MusicBrainz MBID lookups so deferred artists are not queried until later runs.
 - **Artist Essentials & playlist matching**: Disambiguate punctuation-sensitive artist names (e.g. `Gore.` vs `gore`) via Lidarr MBIDs and strict Plex identity checks; Last.fm lookup tries MBID → exact name → normalized fallback with Plex validation before accepting results; resolve Plex track keys once during fetch (parallel Last.fm requests, concurrency via `LASTFM_FETCH_CONCURRENCY`, default 3) instead of re-matching at sync; log when 0/N tracks match for a library artist; do not delete target playlists when saving command settings (only on run when the title changes, or when deleting the command).
 
 ### Housekeeping

--- a/clients/client_plex.py
+++ b/clients/client_plex.py
@@ -998,6 +998,7 @@ class PlexClient(BaseAPIClient):
                         "playlist_title": title,
                         "total_tracks": tracks_total,
                         "found_tracks": 0,
+                        "unmatched_tracks": failed_matches,
                         "message": f"Skipped creating empty playlist '{title}'",
                     }
                 else:
@@ -1011,6 +1012,7 @@ class PlexClient(BaseAPIClient):
                         "playlist_title": title,
                         "total_tracks": tracks_total,
                         "found_tracks": 0,
+                        "unmatched_tracks": failed_matches,
                         "message": f"Skipped creating empty playlist '{title}'",
                     }
 

--- a/commands/playlist_sync.py
+++ b/commands/playlist_sync.py
@@ -259,12 +259,14 @@ class PlaylistSyncCommand(BaseCommand):
         try:
             self.logger.info("Starting artist discovery for unmatched tracks...")
 
-            # Collect unique artists from tracks
-            unique_artists = set()
+            # Collect unique artists in first-seen playlist order
+            unique_artists: list[str] = []
+            seen_artists: set[str] = set()
             for track in tracks:
                 artist = track.get("artist", "").strip()
-                if artist:
-                    unique_artists.add(artist)
+                if artist and artist not in seen_artists:
+                    seen_artists.add(artist)
+                    unique_artists.append(artist)
 
             if not unique_artists:
                 self.logger.info("No artists found in tracks for discovery")
@@ -318,8 +320,6 @@ class PlaylistSyncCommand(BaseCommand):
                     excluded_mbids,
                 ) = await discovery_utils.get_lidarr_context()
 
-                # Process each artist
-                artists_added = 0
                 artists_skipped = 0
                 artists_failed = 0
                 added_artists = []
@@ -327,16 +327,31 @@ class PlaylistSyncCommand(BaseCommand):
                 failed_artists = []
                 new_discoveries = []
 
+                # Filter Lidarr-known names before any MusicBrainz lookups
+                candidates: list[str] = []
                 for artist_name in unique_artists:
-                    try:
-                        # Skip if already in Lidarr (by name)
-                        if artist_name.lower() in existing_names:
-                            artists_skipped += 1
-                            skipped_artists.append(
-                                {"name": artist_name, "reason": "Already in Lidarr"}
-                            )
-                            continue
+                    if artist_name.lower() in existing_names:
+                        artists_skipped += 1
+                        skipped_artists.append(
+                            {"name": artist_name, "reason": "Already in Lidarr"}
+                        )
+                    else:
+                        candidates.append(artist_name)
 
+                # Cap MB lookups before querying (0 = unlimited)
+                limit = self.config_json.get("artist_discovery_max_per_run", 2)
+                artists_deferred = 0
+                to_lookup = candidates
+                if limit > 0 and len(candidates) > limit:
+                    artists_deferred = len(candidates) - limit
+                    to_lookup = candidates[:limit]
+                    self.logger.info(
+                        f"Limiting MusicBrainz lookups to {limit} artists per run; "
+                        f"{artists_deferred} deferred to next run"
+                    )
+
+                for artist_name in to_lookup:
+                    try:
                         # Look up MBID in MusicBrainz
                         mbid_result = await musicbrainz_client.fuzzy_search_artist(artist_name)
 
@@ -375,7 +390,6 @@ class PlaylistSyncCommand(BaseCommand):
                         )
 
                         new_discoveries.append(artist_entry)
-                        artists_added += 1
                         added_artists.append(
                             {"name": artist_name, "resolved_name": resolved_name, "mbid": mbid}
                         )
@@ -389,21 +403,12 @@ class PlaylistSyncCommand(BaseCommand):
 
                 artists_discovered = len(new_discoveries)
                 to_save = []
-                artists_deferred = 0
                 is_first_run = self.config_json.get("is_first_run", False)
                 enable_artist_discovery = self.config_json.get("enable_artist_discovery", False)
 
                 if new_discoveries and not is_first_run and enable_artist_discovery:
-                    limit = self.config_json.get("artist_discovery_max_per_run", 2)
-                    if limit == 0:
-                        to_save = new_discoveries
-                    else:
-                        to_save = new_discoveries[:limit]
-                        artists_deferred = len(new_discoveries) - len(to_save)
-                        if artists_deferred > 0:
-                            self.logger.info(
-                                f"Limiting to {limit} new artists per run; {artists_deferred} deferred to next run"
-                            )
+                    # Lookups were already capped; save all successful discoveries
+                    to_save = new_discoveries
 
                 if to_save:
                     await self._save_discovered_artists(to_save)
@@ -428,7 +433,7 @@ class PlaylistSyncCommand(BaseCommand):
                     "artists_failed": artists_failed,
                     "artists_deferred": artists_deferred,
                     "first_run_preview": is_first_run and artists_discovered > 0,
-                    "added_artists": added_artists[: len(to_save)] if to_save else [],
+                    "added_artists": added_artists if to_save else [],
                     "skipped_artists": skipped_artists,
                     "failed_artists": failed_artists,
                 }

--- a/commands/playlist_sync.py
+++ b/commands/playlist_sync.py
@@ -332,9 +332,7 @@ class PlaylistSyncCommand(BaseCommand):
                 for artist_name in unique_artists:
                     if artist_name.lower() in existing_names:
                         artists_skipped += 1
-                        skipped_artists.append(
-                            {"name": artist_name, "reason": "Already in Lidarr"}
-                        )
+                        skipped_artists.append({"name": artist_name, "reason": "Already in Lidarr"})
                     else:
                         candidates.append(artist_name)
 

--- a/commands/playlist_sync_listenbrainz.py
+++ b/commands/playlist_sync_listenbrainz.py
@@ -1152,8 +1152,30 @@ class PlaylistSyncListenBrainzCommand(PlaylistSyncCommand):
                     f"Lidarr context: {len(existing_mbids)} existing MBIDs, {len(existing_names)} existing names, {len(excluded_mbids)} excluded MBIDs"
                 )
 
-                # Process artists through MusicBrainz
-                artists_without_mbids = [{"name": artist_name} for artist_name in unmatched_artists]
+                # Process artists through MusicBrainz (cap lookups before querying)
+                # Stable order so deferred artists are predictable across runs
+                ordered_artists = sorted(unmatched_artists)
+                candidates = [
+                    name for name in ordered_artists if name.lower() not in existing_names
+                ]
+                skipped_known = len(ordered_artists) - len(candidates)
+                if skipped_known > 0:
+                    self.logger.info(
+                        f"Skipped {skipped_known} unmatched artists already in Lidarr by name"
+                    )
+
+                limit = self.config_json.get("artist_discovery_max_per_run", 2)
+                artists_deferred = 0
+                to_lookup = candidates
+                if limit > 0 and len(candidates) > limit:
+                    artists_deferred = len(candidates) - limit
+                    to_lookup = candidates[:limit]
+                    self.logger.info(
+                        f"Limiting MusicBrainz lookups to {limit} artists per run; "
+                        f"{artists_deferred} deferred to next run"
+                    )
+
+                artists_without_mbids = [{"name": artist_name} for artist_name in to_lookup]
                 self.logger.info(
                     f"Processing {len(artists_without_mbids)} artists through MusicBrainz..."
                 )
@@ -1164,6 +1186,7 @@ class PlaylistSyncListenBrainzCommand(PlaylistSyncCommand):
                     existing_names,
                     excluded_mbids,
                     f"listenbrainz_playlist_sync_{self.config_json.get('unique_id', 'unknown')}",
+                    max_lookups=limit if limit > 0 else None,
                 )
 
                 artists_discovered = len(discovered_artists) if discovered_artists else 0
@@ -1174,19 +1197,10 @@ class PlaylistSyncListenBrainzCommand(PlaylistSyncCommand):
                 is_first_run = self.config_json.get("is_first_run", False)
                 enable_artist_discovery = self.config_json.get("enable_artist_discovery", False)
                 to_save = []
-                artists_deferred = 0
 
                 if discovered_artists and not is_first_run and enable_artist_discovery:
-                    limit = self.config_json.get("artist_discovery_max_per_run", 2)
-                    if limit == 0:
-                        to_save = discovered_artists
-                    else:
-                        to_save = discovered_artists[:limit]
-                        artists_deferred = len(discovered_artists) - len(to_save)
-                        if artists_deferred > 0:
-                            self.logger.info(
-                                f"Limiting to {limit} new artists per run; {artists_deferred} deferred to next run"
-                            )
+                    # Lookups were already capped; save all successful discoveries
+                    to_save = discovered_artists
 
                 if to_save:
                     await self._save_discovered_artists(to_save)

--- a/tests/test_artist_discovery_mb_cap.py
+++ b/tests/test_artist_discovery_mb_cap.py
@@ -88,13 +88,11 @@ async def test_discover_and_add_artists_caps_mb_lookups_before_query():
 
     discovery_utils = MagicMock()
     discovery_utils.get_lidarr_context = AsyncMock(return_value=(set(), set(), set()))
-    discovery_utils.create_artist_entry = (
-        lambda mbid, name, source, **kwargs: {
-            "MusicBrainzId": mbid,
-            "ArtistName": name,
-            "source": source,
-        }
-    )
+    discovery_utils.create_artist_entry = lambda mbid, name, source, **kwargs: {
+        "MusicBrainzId": mbid,
+        "ArtistName": name,
+        "source": source,
+    }
 
     tracks = [{"artist": f"Artist {i}", "track": f"Song {i}"} for i in range(20)]
 

--- a/tests/test_artist_discovery_mb_cap.py
+++ b/tests/test_artist_discovery_mb_cap.py
@@ -1,0 +1,115 @@
+"""Tests that artist discovery caps MusicBrainz lookups before querying."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from commands.playlist_sync import PlaylistSyncCommand
+from utils.discovery import DiscoveryUtils
+
+
+def _make_utils(musicbrainz=None):
+    config = MagicMock()
+    config.MUSICBRAINZ_ENABLED = True
+    return DiscoveryUtils(config=config, lidarr_client=MagicMock(), musicbrainz_client=musicbrainz)
+
+
+@pytest.mark.asyncio
+async def test_process_artists_through_musicbrainz_respects_max_lookups():
+    musicbrainz = MagicMock()
+    musicbrainz.fuzzy_search_artist = AsyncMock(
+        side_effect=lambda name: {
+            "mbid": f"mbid-{name}",
+            "name": name,
+            "similarity_score": 1.0,
+        }
+    )
+    utils = _make_utils(musicbrainz)
+
+    artists = [{"name": f"Artist {i}"} for i in range(10)]
+    recovered = await utils.process_artists_through_musicbrainz(
+        artists,
+        existing_mbids=set(),
+        existing_names=set(),
+        excluded_mbids=set(),
+        source_name="test",
+        max_lookups=2,
+    )
+
+    assert musicbrainz.fuzzy_search_artist.await_count == 2
+    assert len(recovered) == 2
+
+
+@pytest.mark.asyncio
+async def test_process_artists_skips_lidarr_names_before_mb_lookup():
+    musicbrainz = MagicMock()
+    musicbrainz.fuzzy_search_artist = AsyncMock(
+        side_effect=lambda name: {
+            "mbid": f"mbid-{name}",
+            "name": name,
+            "similarity_score": 1.0,
+        }
+    )
+    utils = _make_utils(musicbrainz)
+
+    artists = [{"name": "Known Artist"}, {"name": "New Artist"}]
+    recovered = await utils.process_artists_through_musicbrainz(
+        artists,
+        existing_mbids=set(),
+        existing_names={"known artist"},
+        excluded_mbids=set(),
+        source_name="test",
+        max_lookups=2,
+    )
+
+    assert musicbrainz.fuzzy_search_artist.await_count == 1
+    musicbrainz.fuzzy_search_artist.assert_awaited_once_with("New Artist")
+    assert len(recovered) == 1
+    assert recovered[0]["ArtistName"] == "New Artist"
+
+
+@pytest.mark.asyncio
+async def test_discover_and_add_artists_caps_mb_lookups_before_query():
+    cmd = PlaylistSyncCommand(config=MagicMock())
+    cmd.config.MUSICBRAINZ_ENABLED = True
+    cmd.config_json = {
+        "enable_artist_discovery": True,
+        "artist_discovery_max_per_run": 2,
+        "is_first_run": False,
+        "playlist_name": "Test Playlist",
+    }
+    cmd.logger = MagicMock()
+
+    mb_client = MagicMock()
+    mb_client.fuzzy_search_artist = AsyncMock(
+        side_effect=lambda name: {"mbid": f"mbid-{name}", "name": name}
+    )
+    mb_client.close = AsyncMock()
+
+    discovery_utils = MagicMock()
+    discovery_utils.get_lidarr_context = AsyncMock(return_value=(set(), set(), set()))
+    discovery_utils.create_artist_entry = (
+        lambda mbid, name, source, **kwargs: {
+            "MusicBrainzId": mbid,
+            "ArtistName": name,
+            "source": source,
+        }
+    )
+
+    tracks = [{"artist": f"Artist {i}", "track": f"Song {i}"} for i in range(20)]
+
+    with (
+        patch("clients.client_lidarr.LidarrClient"),
+        patch("clients.client_musicbrainz.MusicBrainzClient", return_value=mb_client),
+        patch("utils.discovery.DiscoveryUtils", return_value=discovery_utils),
+        patch.object(cmd, "_save_discovered_artists", new_callable=AsyncMock) as save_mock,
+    ):
+        stats = await cmd._discover_and_add_artists(tracks, None)
+
+    assert mb_client.fuzzy_search_artist.await_count == 2
+    assert stats["artists_deferred"] == 18
+    assert stats["artists_discovered"] == 2
+    assert stats["artists_added"] == 2
+    save_mock.assert_awaited_once()
+    saved = save_mock.await_args.args[0]
+    assert len(saved) == 2

--- a/tests/test_playlist_title_and_sync_return.py
+++ b/tests/test_playlist_title_and_sync_return.py
@@ -78,3 +78,27 @@ def test_plex_sync_playlist_skipped_empty_return_shape():
     assert SYNC_PLAYLIST_KEYS.issubset(result.keys())
     assert result["playlist_id"] is None
     assert result["playlist_title"] == "Test Playlist"
+
+
+def test_plex_sync_playlist_skipped_empty_includes_unmatched_tracks():
+    """0-match sync must still return unmatched_tracks so artist discovery can run."""
+    client = PlexClient(MagicMock())
+    client.logger = MagicMock()
+    client.config = MagicMock()
+    client.config.PLAYLIST_SYNC_LISTENBRAINZ_CURATED_CLEANUP = True
+    client.search_for_track = MagicMock(return_value=None)
+
+    tracks = [
+        {"artist": "Artist A", "track": "Song 1"},
+        {"artist": "Artist B", "track": "Song 2"},
+    ]
+    result = client.sync_playlist("Empty Library Playlist", tracks, summary="test")
+
+    assert result["success"] is True
+    assert result["action"] == "skipped_empty"
+    assert result["found_tracks"] == 0
+    assert result["total_tracks"] == 2
+    assert result["unmatched_tracks"] == [
+        "Artist A - Song 1",
+        "Artist B - Song 2",
+    ]

--- a/utils/discovery.py
+++ b/utils/discovery.py
@@ -113,6 +113,7 @@ class DiscoveryUtils:
         existing_names: set[str],
         excluded_mbids: set[str],
         source_name: str,
+        max_lookups: int | None = None,
     ) -> list[dict[str, Any]]:
         """
         Process artists without MBIDs through MusicBrainz fuzzy matching with filtering
@@ -123,6 +124,8 @@ class DiscoveryUtils:
             existing_names: Set of artist names already in Lidarr
             excluded_mbids: Set of excluded MBIDs
             source_name: Source identifier for recovered artists
+            max_lookups: Optional cap on MusicBrainz fuzzy searches (None/0 = unlimited).
+                Applied after de-duplicating names and skipping Lidarr-known names.
 
         Returns:
             List of recovered artist dictionaries
@@ -135,18 +138,44 @@ class DiscoveryUtils:
         success_count = 0
         excluded_during_recovery = 0
 
-        # Group by name to avoid duplicate lookups
+        # Group by name to avoid duplicate lookups (preserve first-seen order)
         unique_artists = {}
         for artist in artists_without_mbids:
             name = artist.get("name", artist.get("artistName", ""))
             if name and name not in unique_artists:
                 unique_artists[name] = artist
 
+        # Skip names already in Lidarr before any MusicBrainz queries
+        candidates = {
+            name: data
+            for name, data in unique_artists.items()
+            if name.lower() not in existing_names
+        }
+        skipped_known = len(unique_artists) - len(candidates)
+        if skipped_known > 0:
+            self.logger.debug(
+                f"Skipped {skipped_known} artists already in Lidarr before MusicBrainz lookup"
+            )
+
+        if max_lookups and max_lookups > 0 and len(candidates) > max_lookups:
+            # Preserve insertion order from unique_artists
+            limited = {}
+            for name, data in candidates.items():
+                if len(limited) >= max_lookups:
+                    break
+                limited[name] = data
+            deferred = len(candidates) - len(limited)
+            self.logger.info(
+                f"Limiting MusicBrainz lookups to {max_lookups} artists; "
+                f"{deferred} deferred to next run"
+            )
+            candidates = limited
+
         self.logger.info(
-            f"Processing {len(unique_artists)} unique artist names through MusicBrainz..."
+            f"Processing {len(candidates)} unique artist names through MusicBrainz..."
         )
 
-        for artist_name, artist_data in unique_artists.items():
+        for artist_name, artist_data in candidates.items():
             try:
                 # Fuzzy search in MusicBrainz
                 mb_result = await self.musicbrainz.fuzzy_search_artist(artist_name)

--- a/utils/discovery.py
+++ b/utils/discovery.py
@@ -171,9 +171,7 @@ class DiscoveryUtils:
             )
             candidates = limited
 
-        self.logger.info(
-            f"Processing {len(candidates)} unique artist names through MusicBrainz..."
-        )
+        self.logger.info(f"Processing {len(candidates)} unique artist names through MusicBrainz...")
 
         for artist_name, artist_data in candidates.items():
             try:


### PR DESCRIPTION
Include unmatched tracks in skipped_empty results so discovery still runs at 0/N matches, and apply artist_discovery_max_per_run before MusicBrainz queries.