### PR TITLE
Bump Chainguard Python to 3.14.6-r3 for CVE-2026-11940.

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -137,11 +137,11 @@ jobs:
 
       - name: Run Trivy vulnerability scanner (table)
         run: |
-          if [ -f .trivyignore ]; then
+          if [ -f .trivyignore ] && grep -qE '^CVE-' .trivyignore; then
             echo "### Ignored CVEs (revisit when upstream ships a fix)" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
-            cat .trivyignore >> $GITHUB_STEP_SUMMARY
+            grep -E '^CVE-|^#' .trivyignore >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
           fi

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,3 +1,13 @@
-# Wolfi/Chainguard python:latest runtime CVE ignores.
-# Regenerate after Dockerfile digest bumps:
+# Trivy ignorefile for the published Cmdarr image (Wolfi/Chainguard python runtime).
+#
+# Runtime is Wolfi-only — do not re-add Debian/trixie OS CVE ignores from the
+# retired slim-trixie image. Prefer fixing findings by bumping Dockerfile
+# Chainguard digests (.github/scripts/check-chainguard-python-digest.sh).
+#
+# Only list CVE IDs here when Trivy reports HIGH/CRITICAL with no fixed package
+# yet. Use `exp:YYYY-MM-DD` so CI resurfaces them for review.
+#
+# Verify after digest bumps:
 #   trivy image --severity HIGH,CRITICAL ghcr.io/devianteng/cmdarr:develop
+#
+# No CVE ignores currently (Wolfi python 3.14.6-r3 clean as of 2026-07-15).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Artist Essentials & playlist matching**: Disambiguate punctuation-sensitive artist names (e.g. `Gore.` vs `gore`) via Lidarr MBIDs and strict Plex identity checks; Last.fm lookup tries MBID → exact name → normalized fallback with Plex validation before accepting results; resolve Plex track keys once during fetch (parallel Last.fm requests, concurrency via `LASTFM_FETCH_CONCURRENCY`, default 3) instead of re-matching at sync; log when 0/N tracks match for a library artist; do not delete target playlists when saving command settings (only on run when the title changes, or when deleting the command).
 
 ### Housekeeping
+- **Docker / Trivy**: Bump Chainguard Python digests to **3.14.6-r3** (fixes CVE-2026-11940 on Wolfi runtime); refresh `.trivyignore` comments for Wolfi-only images (no Debian/trixie ignores).
 - **Docker**: Drop Debian-based runtime image; Wolfi/Chainguard (`Dockerfile`, digest-pinned Python 3.14) is now the sole published image. Develop publishes `:develop`; releases publish `latest`, `v0`, `v0.3`, and patch tags only (no `-wolfi` suffix or Debian fallback).
 
 ## [0.3.18] - 2026-07-08

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ COPY frontend/ ./
 RUN npm run build
 
 # Stage 2: Python dependencies (Chainguard dev image — not in final runtime)
-# Locked Python: 3.14.6 (digest pinned 2026-07-08)
-FROM cgr.dev/chainguard/python@sha256:6dd180984927051df465a1914772a4675119e6a998ab9dcfbb7a9269badad387 AS python-builder
+# Locked Python: 3.14.6-r3 (digest pinned 2026-07-15; fixes CVE-2026-11940)
+FROM cgr.dev/chainguard/python@sha256:0416c4863f2d0fb0e2e58d125e03b73cf4876cb02efc7927fd4a248a04f78c24 AS python-builder
 USER root
 WORKDIR /app
 RUN apk add --no-cache gosu
@@ -19,7 +19,7 @@ RUN python -m venv /app/venv \
     && /app/venv/bin/pip install --no-cache-dir -r requirements.txt
 
 # Stage 3: Assemble runtime tree (dev image — shell/apk for mkdir/chown only)
-FROM cgr.dev/chainguard/python@sha256:6dd180984927051df465a1914772a4675119e6a998ab9dcfbb7a9269badad387 AS runtime-assembler
+FROM cgr.dev/chainguard/python@sha256:0416c4863f2d0fb0e2e58d125e03b73cf4876cb02efc7927fd4a248a04f78c24 AS runtime-assembler
 USER root
 WORKDIR /app
 
@@ -33,8 +33,8 @@ COPY docker/entrypoint.py /app/docker/entrypoint.py
 RUN mkdir -p /app/data/logs && chown -R 1000:1000 /app/data
 
 # Stage 4: Distroless Wolfi runtime (COPY only — no RUN)
-# Locked Python: 3.14.6 (digest pinned 2026-07-08)
-FROM cgr.dev/chainguard/python@sha256:522a5ff629869272271784d864da372e03612822902878ecb20b4afc9e797779
+# Locked Python: 3.14.6-r3 (digest pinned 2026-07-15; fixes CVE-2026-11940)
+FROM cgr.dev/chainguard/python@sha256:ce9aaca1f826f7f963cd031e98f8c19f993b1843096d395ea919b646e72cb8de
 
 ARG IMAGE_TAG=latest
 ENV CMDARR_IMAGE_TAG=${IMAGE_TAG}


### PR DESCRIPTION
Refresh .trivyignore for Wolfi-only runtime notes and only summarize ignored CVEs in CI when entries exist.